### PR TITLE
utilities / ensure_called 

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -29,5 +29,13 @@ echo "Testing scripts for custom packages"
 
 echo "Testing utility scripts"
 source utilities/random_timezone.sh
+
+# test check_url
 bash utilities/check_url.sh https://codeship.com
 ! bash utilities/check_url.sh https://does_not_exist.codeship.com
+
+# test ensure_called
+bash utilities/ensure_called.sh "echo Hello World" | grep "Hello World"
+bash utilities/ensure_called.sh true false "echo Hello World" | grep "Hello World"
+! bash utilities/ensure_called.sh false "echo Not Run" true | grep "Not Run"
+! bash utilities/ensure_called.sh

--- a/utilities/ensure_called.sh
+++ b/utilities/ensure_called.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Ensure a separate script is called in the event of an error
+#
+# Include in your builds via
+# \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/utilties/ensure_called.sh > ${HOME}/bin/ensure_called && chmod u+x ${HOME}/bin/ensure_called
+#
+# then use the script in your tests like
+# ensure_called "test command to execute" [command2 ...] "on_exit handler"
+COMMANDS=( "${@?$'\n'Usage: $0 command1 [command2 ...] exit_handler}" )
+EXIT_HANDLER="${@: -1}"
+
+# remove the last element from the COMMANDS array (which is the exit_handler)
+unset "COMMANDS[${#}-1]"
+
+function on_exit() {
+	local exit_code=$?
+	echo -e "\e[33mRunning the exit handler (${EXIT_HANDLER})...\e[39m"
+	${EXIT_HANDLER}
+	echo -e "\e[33m... finished with exit code ${?}\e[39m"
+	exit ${exit_code}
+}
+trap on_exit EXIT
+
+set -e
+
+for command in "${COMMANDS[@]}"; do
+	${command}
+done

--- a/utilities/ensure_called.sh
+++ b/utilities/ensure_called.sh
@@ -2,7 +2,7 @@
 # Ensure a separate script is called in the event of an error
 #
 # Include in your builds via
-# \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/utilties/ensure_called.sh > ${HOME}/bin/ensure_called && chmod u+x ${HOME}/bin/ensure_called
+# \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/utilities/ensure_called.sh > ${HOME}/bin/ensure_called && chmod u+x ${HOME}/bin/ensure_called
 #
 # then use the script in your tests like
 # ensure_called "test command to execute" [command2 ...] "on_exit handler"


### PR DESCRIPTION
A script to make sure an exit handler is run regardless whether other commands fail or not.
Supersedes #46 
