### PR TITLE
a separate go folder per version

### DIFF
--- a/languages/go.sh
+++ b/languages/go.sh
@@ -9,6 +9,8 @@
 # \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/languages/go.sh > ${HOME}/go.sh && source ${HOME}/go.sh
 GO_VERSION=${GO_VERSION:="1.4.2"}
 
+export GOROOT="/tmp/go${GO_VERSION}"
+
 # no set -e because this file is sourced and with the option set a failing command
 # would cause an infrastructur error message on Codeship.
 CACHED_DOWNLOAD="${HOME}/cache/go${GO_VERSION}.linux-amd64.tar.gz"
@@ -18,5 +20,4 @@ wget --continue --output-document "${CACHED_DOWNLOAD}" "https://storage.googleap
 tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${GOROOT}"
 
 # configure the new GOROOT and PATH
-export GOROOT="/tmp/go"
 export PATH="${GOROOT}/bin:${PATH}"


### PR DESCRIPTION
fixes a bug that prevented un-tar-ing go1.5 after go1.4.2 was already on the system
