### PR TITLE
Go Updates

### DIFF
--- a/languages/go.sh
+++ b/languages/go.sh
@@ -9,14 +9,21 @@
 # \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/languages/go.sh > ${HOME}/go.sh && source ${HOME}/go.sh
 GO_VERSION=${GO_VERSION:="1.4.2"}
 
+# strip all components from PATH which point toa GO installation and configure the
+# download location
+CLEANED_PATH=$(echo $PATH | sed -r 's|/(usr/local\|tmp)/go(/([0-9]\.)+[0-9])?/bin:||g')
+CACHED_DOWNLOAD="${HOME}/cache/go${GO_VERSION}.linux-amd64.tar.gz"
+
+# configure the new GOROOT and PATH
+export GOROOT="/tmp/go/${GO_VERSION}"
+export PATH="${GOROOT}/bin:${CLEANED_PATH}"
+
 # no set -e because this file is sourced and with the option set a failing command
 # would cause an infrastructur error message on Codeship.
-CACHED_DOWNLOAD="${HOME}/cache/go${GO_VERSION}.linux-amd64.tar.gz"
 
 mkdir -p "${GOROOT}"
 wget --continue --output-document "${CACHED_DOWNLOAD}" "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz"
 tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${GOROOT}"
 
-# configure the new GOROOT and PATH
-export GOROOT="/tmp/go"
-export PATH="${GOROOT}/bin:${PATH}"
+# check the correct version is yused
+go version | grep ${GO_VERSION}

--- a/test.sh
+++ b/test.sh
@@ -45,8 +45,13 @@ firefox --version | grep "${FIREFOX_VERSION}"
 echo "Testing language scripts"
 export GO_VERSION="1.4.2"
 source languages/go.sh
+go version | grep ${GO_VERSION}
 export GO_VERSION="1.5"
 source languages/go.sh
+go version | grep ${GO_VERSION}
+export GO_VERSION="1.4.2"
+source languages/go.sh
+go version | grep ${GO_VERSION}
 
 echo "Testing utility scripts"
 source utilities/random_timezone.sh


### PR DESCRIPTION
- install go versions to a subfolder of `/tmp/go/${GO_VERSION}`
- add (more) tests
- clear the `$PATH` of other `go/bin` folders (matching the setup on Codeship)

also fixes #67 
