### PR TITLE
Update mongo download url

### DIFF
--- a/packages/mongodb.sh
+++ b/packages/mongodb.sh
@@ -17,7 +17,7 @@ set -e
 CACHED_DOWNLOAD="${HOME}/cache/mongodb-linux-x86_64-ubuntu1404-${MONGODB_VERSION}.tgz"
 
 mkdir -p "${MONGODB_DIR}"
-wget --continue --output-document "${CACHED_DOWNLOAD}" "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1404-${MONGODB_VERSION}.tgz"
+wget --continue --output-document "${CACHED_DOWNLOAD}" "http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1404-${MONGODB_VERSION}.tgz"
 tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${MONGODB_DIR}"
 
 # Make sure to use the exact parameters you want for MongoDB and give it enough sleep time to properly start up


### PR DESCRIPTION
https://fastdl.mongodb.org 
return 403 error code actually
