### PR TITLE
Enable configuration of PhantomJS download host

### DIFF
--- a/packages/phantomjs.sh
+++ b/packages/phantomjs.sh
@@ -3,11 +3,13 @@
 #
 # Add at least the following environment variables to your project configuration
 # (otherwise the defaults below will be used).
-# * PHANTOMJS_VERSION
+# * PHANTOMJS_VERSION - Specify the version of PhantomJS
+# * PHANTOMJS_HOST - Specify the location of the download for the specified version
 #
 # Include in your builds via
 # \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/phantomjs.sh | bash -s
 PHANTOMJS_VERSION=${PHANTOMJS_VERSION:="1.9.8"}
+PHANTOMJS_HOST=${PHANTOMJS_HOST:="https://bitbucket.org/ariya/phantomjs/downloads"}
 
 set -e
 CACHED_DOWNLOAD="${HOME}/cache/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2"
@@ -15,5 +17,5 @@ CACHED_DOWNLOAD="${HOME}/cache/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.b
 # clean old version and setup directories
 rm -rf ~/.phantomjs
 mkdir ~/.phantomjs
-wget --continue --output-document "${CACHED_DOWNLOAD}" "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2"
+wget --continue --output-document "${CACHED_DOWNLOAD}" "${PHANTOMJS_HOST}/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2"
 tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${HOME}/.phantomjs"


### PR DESCRIPTION
Enables setting of a `PHANTOMJS_HOST` variable, which by default remains as `https://bitbucket.org/ariya/phantomjs/downloads` but can now be set to other values, e.g. `https://my-download-host.com/phantomjs`
