### PR TITLE
Prepare for upcoming changes to the ElasticBeanstalk deployment check

### DIFF
--- a/deployments/elastic_beanstalk.sh
+++ b/deployments/elastic_beanstalk.sh
@@ -43,4 +43,4 @@ aws elasticbeanstalk create-application-version --application-name "${AWS_APP_NA
 aws elasticbeanstalk update-environment --environment-name "${AWS_APP_ENVIRONMENT}" --version-label "${AWS_APP_VERSION:0:100}"
 
 # check if the deployment was successful
-eb_deployment_check "${AWS_APP_NAME}" "${AWS_APP_ENVIRONMENT}"
+eb_deployment_check "${AWS_APP_NAME}" "${AWS_APP_ENVIRONMENT}" "${AWS_APP_VERSION:0:100}"

--- a/deployments/elastic_beanstalk.sh
+++ b/deployments/elastic_beanstalk.sh
@@ -39,7 +39,7 @@ zip -x \*/.git\* -x .git\* -x \*.hg\* -r "${DEPLOYMENT_ARCHIVE:=${HOME}/${AWS_AP
 aws s3 cp "${DEPLOYMENT_ARCHIVE}" "s3://${AWS_S3_BUCKET}/${AWS_APP_VERSION}.zip"
 
 # create the new version on ElasticBeanstalk
-aws elasticbeanstalk create-application-version --application-name "${AWS_APP_NAME}" --version-label "${AWS_APP_VERSION:0:100}" --source-bundle S3Bucket="${AWS_S3_BUCKET}",S3Key="subfolder/aws_deployment_${AWS_APPLICATION_VERSION}.zip"
+aws elasticbeanstalk create-application-version --application-name "${AWS_APP_NAME}" --version-label "${AWS_APP_VERSION:0:100}" --source-bundle S3Bucket="${AWS_S3_BUCKET}",S3Key="subfolder/aws_deployment_${AWS_APP_VERSION:0:100}.zip"
 aws elasticbeanstalk update-environment --environment-name "${AWS_APP_ENVIRONMENT}" --version-label "${AWS_APP_VERSION:0:100}"
 
 # check if the deployment was successful


### PR DESCRIPTION
- Pass the version parameter to the `eb_deployment_check` script. It will be ignored right now, but will be used in an upcoming version of the script.
- Also fix a wrongly named variable, which is used in the filename of the archive uploaded to S3

Related to codeship/checkbot#866
