### PR TITLE
Rust installation script

### DIFF
--- a/languages/rust.sh
+++ b/languages/rust.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Install a custom Rust version, https://www.rust-lang.org
+#
+# The script install the latest stable version by default.
+#
+# Include in your builds via
+# source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/languages/rust.sh)"
+RUST_PATH=${RUST_PATH:=$HOME/rust}
+
+curl -sSf curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --disable-sudo --prefix="${RUST_PATH}"
+export PATH="${RUST_PATH}/bin:${PATH}"
+rustc --version

--- a/languages/rust.sh
+++ b/languages/rust.sh
@@ -7,6 +7,6 @@
 # source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/languages/rust.sh)"
 RUST_PATH=${RUST_PATH:=$HOME/rust}
 
-curl -sSf curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --disable-sudo --prefix="${RUST_PATH}"
+curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --disable-sudo --prefix="${RUST_PATH}"
 export PATH="${RUST_PATH}/bin:${PATH}"
 rustc --version

--- a/test.sh
+++ b/test.sh
@@ -61,29 +61,25 @@ bash packages/git-lfs.sh
 git lfs env | grep "git-lfs/${GIT_LFS_VERSION}"
 
 echo "Testing language scripts"
-export GO_VERSION="1.4.2"
-source languages/go.sh
-go version | grep ${GO_VERSION}
-export GO_VERSION="1.5"
-source languages/go.sh
+# Go Lang
 export GO_VERSION="1.6"
-source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/languages/go.sh)"
-go version | grep ${GO_VERSION}
-export GO_VERSION="1.4.2"
 source languages/go.sh
 go version | grep ${GO_VERSION}
+
+# Python
 export PYTHON_VERSION="3.5.1"
 source languages/python.sh
 python --version | grep "${PYTHON_VERSION}"
-#export PYTHON_VERSION="3.5.0"
-#source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/languages/python.sh)"
-#python --version | grep "${PYTHON_VERSION}"
 
+# Erlang
 export ERLANG_VERSION="18.3"
 source languages/erlang.sh
+erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), erlang:display(erlang:binary_to_list(Version)), halt().' -noshell | grep "${ERLANG_VERSION}"
 
+# Elixir, requires the Erlang script above
 export ELIXIR_VERSION="1.2.3"
 source languages/elixir.sh
+elixir --version | grep "${ELIXIR_VERSION}"
 
 echo "Testing utility scripts"
 source utilities/random_timezone.sh

--- a/test.sh
+++ b/test.sh
@@ -81,6 +81,11 @@ export ELIXIR_VERSION="1.2.3"
 source languages/elixir.sh
 elixir --version | grep "${ELIXIR_VERSION}"
 
+# Rust, default to the most recent stable version,
+# doesn't support different versions (yet)
+source languages/rust.sh
+rustc --version
+
 echo "Testing utility scripts"
 source utilities/random_timezone.sh
 


### PR DESCRIPTION
See https://www.rust-lang.org/, based on the `curl` command mentioned on https://www.rust-lang.org/downloads.html and adapted to work on Codeship out of the box.

I also cleaned up the tests for other language installation scripts a bit.
