### PR TITLE
Fix Python version check

### DIFF
--- a/languages/python.sh
+++ b/languages/python.sh
@@ -19,4 +19,4 @@ eval "$(pyenv init -)"
 
 pyenv install "${PYTHON_VERSION}"
 pyenv local "${PYTHON_VERSION}"
-python --version | grep "${PYTHON_VERSION}"
+python --version 2>&1 | grep "${PYTHON_VERSION}"


### PR DESCRIPTION
`python --version` will write to standard error by default, redirect to standard out for `grep`
