### PR TITLE
Checkout git LFS contents when installing

### DIFF
--- a/packages/git-lfs.sh
+++ b/packages/git-lfs.sh
@@ -3,10 +3,11 @@
 #
 # Include in your builds via
 # \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/git-lfs.sh | bash -s
-GIT_LFS_VERSION="1.1.0"
+GIT_LFS_VERSION="1.3.1"
 
 set -e
 GIT_LFS_DIR=${GIT_LFS_DIR:="$HOME/git-lfs"}
+REPO_DIR=$(readlink -f "${HOME}/clone")
 CACHED_DOWNLOAD="${HOME}/cache/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz"
 
 mkdir -p "${GIT_LFS_DIR}"
@@ -15,4 +16,9 @@ tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${GIT_LFS_DIR}"
 
 cd "${GIT_LFS_DIR}"
 PREFIX=${HOME} ./install.sh
+cd -
+
+cd "${REPO_DIR}"
+git lfs fetch
+git lfs checkout
 cd -

--- a/packages/git-lfs.sh
+++ b/packages/git-lfs.sh
@@ -22,3 +22,5 @@ cd "${REPO_DIR}"
 git lfs fetch
 git lfs checkout
 cd -
+
+git lfs version | grep "git-lfs/${GIT_LFS_VERSION}"

--- a/test.sh
+++ b/test.sh
@@ -56,7 +56,7 @@ bash packages/dart.sh
 dart --version 2>&1 | grep "${DART_VERSION}"
 
 # git LFS
-export GIT_LFS_VERSION="1.3.0"
+export GIT_LFS_VERSION="1.3.1"
 bash packages/git-lfs.sh
 git lfs version | grep "git-lfs/${GIT_LFS_VERSION}"
 

--- a/test.sh
+++ b/test.sh
@@ -56,9 +56,9 @@ bash packages/dart.sh
 dart --version 2>&1 | grep "${DART_VERSION}"
 
 # git LFS
-export GIT_LFS_VERSION="1.1.0"
+export GIT_LFS_VERSION="1.3.0"
 bash packages/git-lfs.sh
-git lfs env | grep "git-lfs/${GIT_LFS_VERSION}"
+git lfs version | grep "git-lfs/${GIT_LFS_VERSION}"
 
 # Haskell Stack
 export HASKELL_STACK_VERSION="1.1.0"


### PR DESCRIPTION
- Make sure to run fetch and checkout files stored via LFS
- Update the default version to 1.3.1
