### PR TITLE
Allow passing extra java options

### DIFF
--- a/packages/selenium_server.sh
+++ b/packages/selenium_server.sh
@@ -12,6 +12,7 @@ SELENIUM_VERSION=${SELENIUM_VERSION:="2.46.0"}
 SELENIUM_PORT=${SELENIUM_PORT:="4444"}
 SELENIUM_OPTIONS=${SELENIUM_OPTIONS:=""}
 SELENIUM_WAIT_TIME=${SELENIUM_WAIT_TIME:="10"}
+SELENIUM_JAVA_OPTIONS=${SELENIUM_JAVA_OPTIONS:=""}
 
 set -e
 
@@ -19,6 +20,6 @@ MINOR_VERSION=${SELENIUM_VERSION%.*}
 CACHED_DOWNLOAD="${HOME}/cache/selenium-server-standalone-${SELENIUM_VERSION}.jar"
 
 wget --continue --output-document "${CACHED_DOWNLOAD}" "http://selenium-release.storage.googleapis.com/${MINOR_VERSION}/selenium-server-standalone-${SELENIUM_VERSION}.jar"
-java -jar "${CACHED_DOWNLOAD}" -port "${SELENIUM_PORT}" ${SELENIUM_OPTIONS} 2>&1 &
+java ${SELENIUM_JAVA_OPTIONS} -jar "${CACHED_DOWNLOAD}" -port "${SELENIUM_PORT}" ${SELENIUM_OPTIONS} 2>&1 &
 sleep "${SELENIUM_WAIT_TIME}"
 echo "Selenium ${SELENIUM_VERSION} is now ready to connect on port ${SELENIUM_PORT}..."


### PR DESCRIPTION
this is handy when you need to change selenium logging level with example option:
 -Djava.util.logging.config.file=/tmp/logOptions.properties

(otherwise Selenium produces MASSIVE amount of INFO level logs making e2e test unreadable)
