### PR TITLE
Install a custom ChromeDriver version

### DIFF
--- a/packages/chromedriver.sh
+++ b/packages/chromedriver.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Install a custom ChromeDriver version, https://sites.google.com/a/chromium.org/chromedriver/
+#
+# Add at least the following environment variables to your project configuration
+# (otherwise the defaults below will be used).
+# * CHROMEDRIVER_VERSION
+#
+# Include in your builds via
+# \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/chromedriver.sh | bash -s
+CHROMEDRIVER_VERSION=${CHROMEDRIVER_VERSION:="2.24"}
+
+set -e
+CACHED_DOWNLOAD="${HOME}/cache/chromedriver_linux64_${CHROMEDRIVER_VERSION}.zip"
+
+rm -rf "${HOME}/bin/chromedriver"
+wget --continue --output-document "${CACHED_DOWNLOAD}" "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+unzip -o "${CACHED_DOWNLOAD}" -d "${HOME}/bin"
+
+chromedriver --version | grep "${CHROMEDRIVER_VERSION}"

--- a/test.sh
+++ b/test.sh
@@ -60,6 +60,11 @@ export GIT_LFS_VERSION="1.4.0"
 bash packages/git-lfs.sh
 git lfs version | grep "git-lfs/${GIT_LFS_VERSION}"
 
+# ChromeDriver
+export CHROMEDRIVER_VERSION="2.24"
+bash packages/chromedriver.sh
+chromedriver --version | grep "ChromeDriver ${CHROMEDRIVER_VERSION}"
+
 # Haskell Stack
 export HASKELL_STACK_VERSION="1.1.0"
 bash packages/stack.sh


### PR DESCRIPTION
Install a custom version of [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/) for use on the Codeship build VMs.

Add the following to your setup steps to make use of it.

``` bash
export CHROMEDRIVER_VERSION="2.24"
\curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/chromedriver.sh | bash -s
```

(once this PR is merged)
