### PR TITLE
Add a script to test whether a port is open or not

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -136,8 +136,8 @@ WGET_OPTIONS="--no-check-certificate" bash utilities/check_url.sh -w 2 -t 2 http
 ! bash utilities/check_url.sh -w 2 -t 2 https://cacert.org
 
 # test check_port
-bash utilities/check_port 3306
-! bash utilities/check_port 80
+bash utilities/check_port.sh 3306
+! bash utilities/check_port.sh 80
 
 # test ensure_called
 bash utilities/ensure_called.sh "echo Hello World" | grep "Hello World"

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -134,6 +134,10 @@ bash utilities/check_url.sh -w 2 -t 2 https://codeship.com
 # test check_url certificate warnings
 WGET_OPTIONS="--no-check-certificate" bash utilities/check_url.sh -w 2 -t 2 https://cacert.org
 ! bash utilities/check_url.sh -w 2 -t 2 https://cacert.org
+
+# test check_port
+bash utilities/check_port 3306
+! bash utilities/check_port 80
 
 # test ensure_called
 bash utilities/ensure_called.sh "echo Hello World" | grep "Hello World"

--- a/utilities/check_port.sh
+++ b/utilities/check_port.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Check a whether a port is open or not
+#
+# Include in your builds via
+# \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/utilities/check_port.sh > ${HOME}/bin/check_port && chmod u+x ${HOME}/bin/check_port
+#
+# then use the script in your tests like
+# check_port 9200
+
+function check_port() {
+  local host=${1} && shift
+  local port=${1} && shift
+  local retries=5
+  local wait=1
+
+  until( nc -zv ${host} ${port} ); do
+    ((retries--))
+    if [ $retries -lt 0 ]; then
+      echo "Service ${host}:${port} didn't become ready in time."
+      exit 1
+    fi
+    sleep "${wait}"
+  done
+}
+
+check_port "localhost" "$@"


### PR DESCRIPTION
Can be used to check e.g. if MySQL or ElasticSearch ports are already open. This doesn't test if the service is actually ready, but only if the port is open.

``` bash
# will return an error (as we don't have a HTTP server installed and listening on port 80)
check_port 80

# will work (as MySQL is listening on port 3306)
check_port 3306
```
