### PR TITLE
Fix parameter for wait time option

### DIFF
--- a/utilities/check_url.sh
+++ b/utilities/check_url.sh
@@ -10,7 +10,7 @@ OPTIONS=${WGET_OPTIONS:="--output-document=/dev/null"}
 TRIES=6
 WAIT=10
 
-while getopts "t:w" opt; do
+while getopts "t:w:" opt; do
   case $opt in
     t)
       TRIES=${OPTARG}


### PR DESCRIPTION
The `-w` option supports a parameter, which we forgot to mention when writing the initial script :(

closes #117 
