### PR TITLE
Use correct download location for Elasticsearch v5.x

### DIFF
--- a/packages/elasticsearch.sh
+++ b/packages/elasticsearch.sh
@@ -15,8 +15,11 @@ ELASTICSEARCH_PORT=${ELASTICSEARCH_PORT:="9333"}
 ELASTICSEARCH_DIR=${ELASTICSEARCH_DIR:="$HOME/el"}
 ELASTICSEARCH_WAIT_TIME=${ELASTICSEARCH_WAIT_TIME:="30"}
 
-# The download location of version 2.x seems to follow a different URL structure to 1.x
-if [ ${ELASTICSEARCH_VERSION:0:1} -eq 2 ]
+# The download location of version 5.x, and 2.x seems to follow a different URL structure to 1.x
+if [ ${ELASTICSEARCH_VERSION:0:1} -eq 5 ]
+then
+  ELASTICSEARCH_DL_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz"
+elif [ ${ELASTICSEARCH_VERSION:0:1} -eq 2 ]
 then
   ELASTICSEARCH_DL_URL="https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ELASTICSEARCH_VERSION}/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz"
 else


### PR DESCRIPTION
Elasticsearch seems to have changed the location to download release 5.x from again (it was also changed for version 1.x and 2.x). This patch adds an additional condition to the Elasticsearch installation script to install from the new location.