### PR TITLE
Switch to subshells

### DIFF
--- a/packages/dynamodb.sh
+++ b/packages/dynamodb.sh
@@ -21,7 +21,8 @@ wget --continue --output-document "${CACHED_DOWNLOAD}" "https://s3-us-west-2.ama
 tar -xaf "${CACHED_DOWNLOAD}" --directory "${DYNAMODB_DIR}"
 
 # Make sure to use the exact parameters you want for DynamoDB and give it enough sleep time to properly start up
-cd ${DYNAMODB_DIR}
-nohup bash -c "java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -sharedDb -inMemory -port ${DYNAMODB_PORT} 2>&1" &
-sleep "${DYNAMODB_WAIT_TIME}"
-cd -
+(
+  cd ${DYNAMODB_DIR} || exit 1
+  nohup bash -c "java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -sharedDb -inMemory -port ${DYNAMODB_PORT} 2>&1" &
+  sleep "${DYNAMODB_WAIT_TIME}"
+)

--- a/packages/git-lfs.sh
+++ b/packages/git-lfs.sh
@@ -14,13 +14,15 @@ mkdir -p "${GIT_LFS_DIR}"
 wget --continue --output-document "${CACHED_DOWNLOAD}" "https://github.com/github/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz"
 tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${GIT_LFS_DIR}"
 
-cd "${GIT_LFS_DIR}"
-PREFIX=${HOME} ./install.sh
-cd -
+(
+  cd "${GIT_LFS_DIR}" || exit 1
+  PREFIX=${HOME} ./install.sh
+)
 
-cd "${REPO_DIR}"
-git lfs fetch
-git lfs checkout
-cd -
+(
+  cd "${REPO_DIR}" || exit 1
+  git lfs fetch
+  git lfs checkout
+)
 
 git lfs version | grep "git-lfs/${GIT_LFS_VERSION}"

--- a/packages/git.sh
+++ b/packages/git.sh
@@ -16,11 +16,13 @@ CACHED_DOWNLOAD="${HOME}/cache/git-${GIT_VERSION}.zip"
 
 wget --continue --output-document "${CACHED_DOWNLOAD}" "https://github.com/git/git/archive/v${GIT_VERSION}.zip"
 unzip -q "${CACHED_DOWNLOAD}" -d "${HOME}"
-cd "${HOME}/git-${GIT_VERSION}"
-autoconf
-./configure --prefix="${HOME}"
-make
-make install
-cd -
+
+(
+  cd "${HOME}/git-${GIT_VERSION}" || exit 1
+  autoconf
+  ./configure --prefix="${HOME}"
+  make
+  make install
+)
 
 git --version | grep "${GIT_VERSION}"


### PR DESCRIPTION
Clearing up some ShellCheck messages like this:

```
In packages/git.sh line 24:
cd -
^-- SC2103: Use a ( subshell ) to avoid having to cd back.
```