### PR TITLE
Updates to the python installer

### DIFF
--- a/languages/python.sh
+++ b/languages/python.sh
@@ -9,15 +9,21 @@
 # Include in your builds via
 # source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/languages/python.sh)"
 PYTHON_VERSION=${PYTHON_VERSION:="3.5.0"}
+PYENV_VERSION=${PYENV_VERSION:="v1.0.8"}
+
 PYENV_ROOT=${PYENV_ROOT:=$HOME/pyenv}
+CACHED_DOWNLOAD="${HOME}/cache/pyenv-${PYENV_VERSION}.tar.gz"
 
-git clone https://github.com/yyuu/pyenv.git "${PYENV_ROOT}"
+if [ ! -d "${PYENV_ROOT}" ]; then
+  mkdir -p "${PYENV_ROOT}"
+  wget --continue --output-document "${CACHED_DOWNLOAD}" "https://github.com/yyuu/pyenv/archive/${PYENV_VERSION}.tar.gz"
+  tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${PYENV_ROOT}"
 
-export PYENV_ROOT
-export PATH="${PYENV_ROOT}/bin:${PATH}"
+  export PYENV_ROOT
+  export PATH="${PYENV_ROOT}/bin:${PATH}"
+fi
 
 eval "$(pyenv init -)"
-
-pyenv install "${PYTHON_VERSION}"
+pyenv install --skip-existing "${PYTHON_VERSION}"
 pyenv local "${PYTHON_VERSION}"
 python --version 2>&1 | grep "${PYTHON_VERSION}"


### PR DESCRIPTION
* Switch pyenv from user git master to the latest release available on Github
* Configure pyenv to skip installing a version if it is already available locally
* Skip installing pyenv if a $HOME/pyenv directory already exists

Addresses the issues mentioned in #135, requires #134 to be merged for passing tests.