### PR TITLE
Update to Git LFS 2.0.0

### DIFF
--- a/packages/git-lfs.sh
+++ b/packages/git-lfs.sh
@@ -3,7 +3,15 @@
 #
 # Include in your builds via
 # \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/git-lfs.sh | bash -s
-GIT_LFS_VERSION=${GIT_LFS_VERSION:="2.0.0"}
+
+# print a warning message if a user relies on the default version
+# we are going to upgrade to 2.0.0 in the future
+if [ -z ${GIT_LFS_VERSION} ]; then
+	echo -e "\e[0;33mWarning: You are relying on the default version of Git LFS.\e[0m"
+	echo -e "\e[0;33mWe will update this script to switch to version 2.0.0 in the near future, which will break support for the legacy API v0.5.0. Please either specify the GIT_LFS_VERSION environment variable or update your Git LFS server.\e[0m"
+	echo -e "\e[0;33mPlease see https://github.com/git-lfs/git-lfs/releases/tag/v2.0.0 for more information.\e[0m"
+fi
+GIT_LFS_VERSION=${GIT_LFS_VERSION:="1.5.6"}
 
 set -e
 GIT_LFS_DIR=${GIT_LFS_DIR:="$HOME/git-lfs"}

--- a/packages/git-lfs.sh
+++ b/packages/git-lfs.sh
@@ -3,7 +3,7 @@
 #
 # Include in your builds via
 # \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/git-lfs.sh | bash -s
-GIT_LFS_VERSION=${GIT_LFS_VERSION:="1.4.0"}
+GIT_LFS_VERSION=${GIT_LFS_VERSION:="2.0.0"}
 
 set -e
 GIT_LFS_DIR=${GIT_LFS_DIR:="$HOME/git-lfs"}

--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -18,9 +18,15 @@ bash packages/git.sh
 git --version | grep "${GIT_VERSION}"
 
 # Git LFS
-export GIT_LFS_VERSION="1.5.6"
+export GIT_LFS_VERSION="2.0.0"
 bash packages/git-lfs.sh
 git lfs version | grep "git-lfs/${GIT_LFS_VERSION}"
+
+# test warning message
+unset GIT_LFS_VERSION
+bash packages/git-lfs.sh | grep "Warning"
+git lfs version | grep "git-lfs/1.5.6"
+
 
 # ImageMagick
 export IMAGEMAGICK_VERSION="7.0.5-0"


### PR DESCRIPTION
See https://github.com/blog/2328-git-lfs-2-0-0-released and https://github.com/git-lfs/git-lfs/releases/tag/v2.0.0 for the release notes.

I'm not sure we can merge this as is, because of the following deprecation.

Maybe we should update the default installation to 1.5.6 and add a warning?

> Deprecations
> 
> Git LFS v2.0.0 also drops support for the legacy API in v0.5.0. If you're still using LFS servers on the old API, you'll have to stick to v1.5.6.