### PR TITLE
Move Dart to languages

### DIFF
--- a/languages/dart.sh
+++ b/languages/dart.sh
@@ -6,7 +6,7 @@
 # * DART_VERSION
 #
 # Include in your builds via
-# \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/dart.sh | bash -s
+# \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/languages/dart.sh | bash -s
 DART_VERSION=${DART_VERSION:="1.13.0"}
 
 set -e

--- a/tests/languages.sh
+++ b/tests/languages.sh
@@ -4,7 +4,7 @@ set -e
 
 # Dart
 export DART_VERSION="1.22.1"
-bash packages/dart.sh
+bash languages/dart.sh
 dart --version 2>&1 | grep "${DART_VERSION}"
 
 # Erlang


### PR DESCRIPTION
Moving the Dart script over to the languages folder.  I did a quick Dataclips query for projects calling the script and did not find any so I think we are safe to move this.