### PR TITLE
Update Tomcat download URL

### DIFF
--- a/packages/tomcat.sh
+++ b/packages/tomcat.sh
@@ -18,7 +18,7 @@ set -e
 CACHED_DOWNLOAD="${HOME}/cache/apache-tomcat-${TOMCAT_VERSION}.tar.gz"
 
 mkdir -p "${TOMCAT_DIR}"
-wget --continue --output-document "${CACHED_DOWNLOAD}" "http://www-us.apache.org/dist/tomcat/tomcat-${TOMCAT_VERSION:0:1}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz"
+wget --continue --output-document "${CACHED_DOWNLOAD}" "https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_VERSION:0:1}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz"
 tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${TOMCAT_DIR}"
 
 if [ "$TOMCAT_AUTOSTART" -eq "1" ]; then

--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -72,6 +72,6 @@ bash packages/stack.sh
 stack --version | grep "${HASKELL_STACK_VERSION}"
 
 # Tomcat
-export TOMCAT_VERSION="8.5.11"
+export TOMCAT_VERSION="8.5.12"
 bash packages/tomcat.sh
 bash ${HOME}/tomcat/bin/version.sh | grep "Apache Tomcat/${TOMCAT_VERSION}"


### PR DESCRIPTION
Switched to a different URL that should be static even when a newer Tomcat version comes out.