### PR TITLE
Source jdk_switcher to use it

### DIFF
--- a/packages/elasticsearch.sh
+++ b/packages/elasticsearch.sh
@@ -17,6 +17,7 @@ ELASTICSEARCH_WAIT_TIME=${ELASTICSEARCH_WAIT_TIME:="30"}
 
 # The download location of version 5.x, and 2.x seems to follow a different URL structure to 1.x\
 # Make sure to use Oracle JDK 8 for Elasticsearch 5.x run the following commands in your script.
+# source $HOME/bin/jdk/jdk_switcher
 # jdk_switcher home oraclejdk8
 # jdk_switcher use oraclejdk8
 if [ ${ELASTICSEARCH_VERSION:0:1} -eq 5 ]


### PR DESCRIPTION
jdk_switcher is a bash function which isn't inherited by sub-shells, thus invoking it here without sourcing it will not work and ultimately fail switching the JDK which is e.g. required for ES5