### PR TITLE
Switch ImageMagick download location

### DIFF
--- a/packages/imagemagick.sh
+++ b/packages/imagemagick.sh
@@ -9,16 +9,16 @@
 # (otherwise the default below will be used).
 # * IMAGEMAGICK_VERSION
 #
-IMAGEMAGICK_VERSION=${IMAGEMAGICK_VERSION:="7.0.5-3"}
+IMAGEMAGICK_VERSION=${IMAGEMAGICK_VERSION:="7.0.5-0"}
 IMAGEMAGICK_DIR=${IMAGEMAGICK_DIR:=$HOME/cache/imagemagick-$IMAGEMAGICK_VERSION}
 
 set -e
 
 if [ ! -d "${IMAGEMAGICK_DIR}" ]; then
-  CACHED_DOWNLOAD="${HOME}/cache/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+  CACHED_DOWNLOAD="${HOME}/cache/ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz"
 
   mkdir -p "${HOME}/imagemagick"
-  wget --continue --output-document "${CACHED_DOWNLOAD}" "https://www.imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz"
+  wget --continue --output-document "${CACHED_DOWNLOAD}" "http://git.imagemagick.org/repos/ImageMagick/repository/archive.tar.gz?ref=${IMAGEMAGICK_VERSION}"
   tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${HOME}/imagemagick"
 
   (

--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -37,7 +37,7 @@ source packages/google-cloud-sdk.sh
 gcloud --version
 
 # ImageMagick
-export IMAGEMAGICK_VERSION="7.0.5-3"
+export IMAGEMAGICK_VERSION="7.0.5-0"
 bash packages/imagemagick.sh
 identify -version | grep "${IMAGEMAGICK_VERSION}"
 


### PR DESCRIPTION
Switching download over to ImageMagick's official repo so the download link doesn't break when they release a newer version.