### PR TITLE
Fix MySQL 5.7 script

### DIFF
--- a/packages/mysql-5.7.sh
+++ b/packages/mysql-5.7.sh
@@ -55,6 +55,7 @@ bind-address		= 127.0.0.1
 max_allowed_packet	= 16M
 thread_stack		= 192K
 thread_cache_size	= 8
+innodb_use_native_aio	= 0
 
 # * Query Cache Configuration
 query_cache_limit	= 1M


### PR DESCRIPTION
Not sure what changed in the image, but noticed this script was breaking and the error log pointed me to adding this line as a fix.  Seems to clear up the issue.

http://unix.stackexchange.com/questions/116520/mysql-server-wont-install-to-a-new-os-debian-ubuntu