### PR TITLE
Isolate ElasticSearch better

### DIFF
--- a/packages/elasticsearch.sh
+++ b/packages/elasticsearch.sh
@@ -40,5 +40,5 @@ tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${ELASTICSEARCH_
 echo "http.port: ${ELASTICSEARCH_PORT}" >> ${ELASTICSEARCH_DIR}/config/elasticsearch.yml
 
 # Make sure to use the exact parameters you want for ElasticSearch and give it enough sleep time to properly start up
-nohup bash -c "${ELASTICSEARCH_DIR}/bin/elasticsearch 2>&1" &
+nohup bash -c "${ELASTICSEARCH_DIR}/bin/elasticsearch -Des.cluster.name=\"${CI_REPO_NAME}_${CI_BUILD_NUMBER}\" -Des.network.host=\"127.0.0.1\" 2>&1" &
 sleep "${ELASTICSEARCH_WAIT_TIME}"


### PR DESCRIPTION
* Configure an explicit cluster name (based on the repository name and the build ID)
* Use the loopback device for networking