### PR TITLE
Switch (some) tests to Bats

### DIFF
--- a/packages/bats.sh
+++ b/packages/bats.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Install Bats - https://github.com/sstephenson/bats
+#
+# Include in your builds via
+# \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/bats.sh | bash -s
+BATS_VERSION="0.4.0"
+
+set -e
+CACHED_DOWNLOAD="${HOME}/cache/bats-${BATS_VERSION}.tar.gz"
+
+wget --continue --output-document "${CACHED_DOWNLOAD}" "https://github.com/sstephenson/bats/archive/v${BATS_VERSION}.tar.gz"
+tar -xaf "${CACHED_DOWNLOAD}" --directory "${HOME}"
+mkdir -p "${HOME}/bats"
+(
+	cd "${HOME}/bats-${BATS_VERSION}"
+	./install.sh "${HOME}/bats"
+)
+rm -rf "${HOME}/bats-${BATS_VERSION}"
+ln -fs "${HOME}/bats/bin/bats" "${HOME}/bin/"
+
+bats --version

--- a/tests/cache.sh
+++ b/tests/cache.sh
@@ -2,5 +2,9 @@
 
 set -e
 
-# Test bower
-bash cache/bower.sh
+echo "Installing Bats"
+bash ./packages/bats.sh
+
+echo "Running Caching Tests"
+chmod u+x ./cache/*
+bats --pretty ./tests/cache

--- a/tests/cache/bower.bats
+++ b/tests/cache/bower.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "bower" {
+  run "./cache/bower.sh"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
* Add a script to install Bats
* Move testing the (Bower) cache script to Bats and adapt the `tests/cache.sh` script accordingly.

Build on Codeship: https://app.codeship.com/projects/74080/builds/24643209?pipeline=c1c17867-014f-470a-8fd3-1dc82b312623

Next steps
* [x] Install Bats during the setup commands (#160)
* [ ] Make shell scripts executable during the setup commands
* [ ] Convert more tests to the Bats format
* [ ] Call `bats` directly from the test commands without a wrapper script