### PR TITLE
Convert utility tests to bats

### DIFF
--- a/tests/cache/bower.bats
+++ b/tests/cache/bower.bats
@@ -9,7 +9,7 @@ teardown() {
   rm -rf "./node_modules" "${HOME}/cache/*"
 }
 
-@test "Configure caching bower packages" {
+@test "[bower.sh] Configure caching bower packages" {
   run "./cache/bower.sh"
   [ "$status" -eq 0 ]
 	[ -f ${HOME}/.bowerrc ]
@@ -17,7 +17,7 @@ teardown() {
 	[[ $(cat ${HOME}/.bowerrc | grep registry) =~ "${HOME}/cache" ]]
 }
 
-@test "Check if bower is writing to the cache directory" {
+@test "[bower.sh] Check if bower is writing to the cache directory" {
 	run bash -c "npm install bower && bower install jquery"
 	[ "$status" -eq 0 ]
 	[ $(du -s ${HOME}/cache/bower | cut -f 1) -ne 0 ]

--- a/tests/cache/bower.bats
+++ b/tests/cache/bower.bats
@@ -10,7 +10,7 @@ teardown() {
 }
 
 @test "[bower.sh] Configure caching bower packages" {
-  run "./cache/bower.sh"
+  run ./cache/bower.sh
   [ "$status" -eq 0 ]
 	[ -f ${HOME}/.bowerrc ]
 	[[ $(cat ${HOME}/.bowerrc | grep packages) =~ "${HOME}/cache" ]]

--- a/tests/utilities.sh
+++ b/tests/utilities.sh
@@ -23,3 +23,6 @@ bash utilities/ensure_called.sh true false "echo Hello World" | grep "Hello Worl
 # Test random_timezone
 source utilities/random_timezone.sh
 env | grep TZ
+
+# Run bats tests
+bats ./tests/utilities/

--- a/tests/utilities/check_port.bats
+++ b/tests/utilities/check_port.bats
@@ -7,12 +7,12 @@ setup() {
 teardown() {
 }
 
-@test "Check open port 3306" {
+@test "[check_port.sh] Check open port 3306" {
 	run "./utilities/check_port 3306"
 	[ "$status" -eq 0 ]
 }
 
-@test "Check closed port 80" {
+@test "[check_port.sh] Check closed port 80" {
 	run "./utilities/check_port 80"
 	[ "$status" -eq 1 ]
 	[ "$output" = "Service localhost:80 didn't become ready in time." ]

--- a/tests/utilities/check_port.bats
+++ b/tests/utilities/check_port.bats
@@ -5,12 +5,12 @@ setup() {
 }
 
 @test "[check_port.sh] Check open port 3306" {
-	run "./utilities/check_port 3306"
+	run ./utilities/check_port.sh 3306
 	[ "$status" -eq 0 ]
 }
 
 @test "[check_port.sh] Check closed port 80" {
-	run "./utilities/check_port 80"
+	run ./utilities/check_port.sh 80
 	[ "$status" -eq 1 ]
 	[ "$output" = "Service localhost:80 didn't become ready in time." ]
 }

--- a/tests/utilities/check_port.bats
+++ b/tests/utilities/check_port.bats
@@ -12,5 +12,5 @@ setup() {
 @test "[check_port.sh] Check closed port 80" {
 	run ./utilities/check_port.sh 80
 	[ "$status" -eq 1 ]
-	[ "$output" = "Service localhost:80 didn't become ready in time." ]
+	[[ "$output" =~ "Service localhost:80 didn't become ready in time." ]]
 }

--- a/tests/utilities/check_port.bats
+++ b/tests/utilities/check_port.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+setup() {
+	chmod u+x ./utilities/check_port.sh
+}
+
+teardown() {
+}
+
+@test "Check open port 3306" {
+	run "./utilities/check_port 3306"
+	[ "$status" -eq 0 ]
+}
+
+@test "Check closed port 80" {
+	run "./utilities/check_port 80"
+	[ "$status" -eq 1 ]
+	[ "$output" = "Service localhost:80 didn't become ready in time." ]
+}

--- a/tests/utilities/check_port.bats
+++ b/tests/utilities/check_port.bats
@@ -4,9 +4,6 @@ setup() {
 	chmod u+x ./utilities/check_port.sh
 }
 
-teardown() {
-}
-
 @test "[check_port.sh] Check open port 3306" {
 	run "./utilities/check_port 3306"
 	[ "$status" -eq 0 ]

--- a/tests/utilities/check_url.bats
+++ b/tests/utilities/check_url.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+	chmod u+x ./utilities/check_url.sh
+}
+
+teardown() {
+}
+
+@test "Check valid URL https://codeship.com" {
+	run "./utilities/check_url.sh -w 2 -t 2 https://codeship.com"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Trying (1 of 2) 'wget --output-document=/dev/null -w 2 -t 2 https://codeship.com'" ]]
+}
+
+@test "Check invlid URL https://does_not_exist.codeship.com" {
+	run "./utilities/check_url.sh -w 2 -t 2 https://does_not_exist.codeship.com"
+	[ "$status" -ne 0 ]
+	[[ "$output" =~ "Trying (1 of 2) 'wget --output-document=/dev/null -w 2 -t 2 https://does_not_exist.codeship.com'" ]]
+}
+
+@test "Check certificate is not ignored by default" {
+	run "./utilities/check_url.sh -w 2 -t 2 https://cacert.org"
+	[ "$status" -ne 0 ]
+}
+
+@test "Check certificate is ignored if '--no-check-certificate' is provided via WGET_OPTIONS environment variable" {
+	run "WGET_OPTIONS='--no-check-certificate' ./utilities/check_url.sh -w 2 -t 2 https://cacert.org"
+	[ "$status" -eq 0 ]
+}

--- a/tests/utilities/check_url.bats
+++ b/tests/utilities/check_url.bats
@@ -7,24 +7,24 @@ setup() {
 teardown() {
 }
 
-@test "Check valid URL https://codeship.com" {
+@test "[check_url.sh] Check valid URL https://codeship.com" {
 	run "./utilities/check_url.sh -w 2 -t 2 https://codeship.com"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "Trying (1 of 2) 'wget --output-document=/dev/null -w 2 -t 2 https://codeship.com'" ]]
 }
 
-@test "Check invlid URL https://does_not_exist.codeship.com" {
+@test "[check_url.sh] Check invlid URL https://does_not_exist.codeship.com" {
 	run "./utilities/check_url.sh -w 2 -t 2 https://does_not_exist.codeship.com"
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "Trying (1 of 2) 'wget --output-document=/dev/null -w 2 -t 2 https://does_not_exist.codeship.com'" ]]
 }
 
-@test "Check certificate is not ignored by default" {
+@test "[check_url.sh] Check certificate is not ignored by default" {
 	run "./utilities/check_url.sh -w 2 -t 2 https://cacert.org"
 	[ "$status" -ne 0 ]
 }
 
-@test "Check certificate is ignored if '--no-check-certificate' is provided via WGET_OPTIONS environment variable" {
+@test "[check_url.sh] Check certificate is ignored if '--no-check-certificate' is provided via WGET_OPTIONS environment variable" {
 	run "WGET_OPTIONS='--no-check-certificate' ./utilities/check_url.sh -w 2 -t 2 https://cacert.org"
 	[ "$status" -eq 0 ]
 }

--- a/tests/utilities/check_url.bats
+++ b/tests/utilities/check_url.bats
@@ -4,9 +4,6 @@ setup() {
 	chmod u+x ./utilities/check_url.sh
 }
 
-teardown() {
-}
-
 @test "[check_url.sh] Check valid URL https://codeship.com" {
 	run "./utilities/check_url.sh -w 2 -t 2 https://codeship.com"
 	[ "$status" -eq 0 ]

--- a/tests/utilities/check_url.bats
+++ b/tests/utilities/check_url.bats
@@ -5,23 +5,23 @@ setup() {
 }
 
 @test "[check_url.sh] Check valid URL https://codeship.com" {
-	run "./utilities/check_url.sh -w 2 -t 2 https://codeship.com"
+	run ./utilities/check_url.sh -w 2 -t 2 "https://codeship.com"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "Trying (1 of 2) 'wget --output-document=/dev/null -w 2 -t 2 https://codeship.com'" ]]
 }
 
 @test "[check_url.sh] Check invlid URL https://does_not_exist.codeship.com" {
-	run "./utilities/check_url.sh -w 2 -t 2 https://does_not_exist.codeship.com"
+	run ./utilities/check_url.sh -w 2 -t 2 "https://does_not_exist.codeship.com"
 	[ "$status" -ne 0 ]
 	[[ "$output" =~ "Trying (1 of 2) 'wget --output-document=/dev/null -w 2 -t 2 https://does_not_exist.codeship.com'" ]]
 }
 
 @test "[check_url.sh] Check certificate is not ignored by default" {
-	run "./utilities/check_url.sh -w 2 -t 2 https://cacert.org"
+	run ./utilities/check_url.sh -w 2 -t 2 "https://cacert.org"
 	[ "$status" -ne 0 ]
 }
 
 @test "[check_url.sh] Check certificate is ignored if '--no-check-certificate' is provided via WGET_OPTIONS environment variable" {
-	run "WGET_OPTIONS='--no-check-certificate' ./utilities/check_url.sh -w 2 -t 2 https://cacert.org"
+	run bash -c "WGET_OPTIONS='--no-check-certificate' ./utilities/check_url.sh -w 2 -t 2 https://cacert.org"
 	[ "$status" -eq 0 ]
 }

--- a/tests/utilities/ensure_called.bats
+++ b/tests/utilities/ensure_called.bats
@@ -5,26 +5,26 @@ setup() {
 }
 
 @test "[ensure_called.sh] Check with a single argument" {
-	run "./utilities/ensure_called.sh 'echo Hello World'"
+	run ./utilities/ensure_called.sh 'echo Hello World'
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "Hello World" ]]
 	[[ "$output" =~ "Running the exit handler" ]]
 }
 
 @test "[ensure_called.sh] Check with no argument" {
-	run "./utilities/ensure_called.sh"
+	run ./utilities/ensure_called.sh
 	[ "$status" -ne 0 ]
 }
 
 @test "[ensure_called.sh] Check that the exit handler is called in case of an error" {
-	run "./utilities/ensure_called.sh true false 'echo Hello World'"
+	run ./utilities/ensure_called.sh true false 'echo Hello World'
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "Hello World" ]]
 	[[ "$output" =~ "Running the exit handler" ]]
 }
 
 @test "[ensure_called.sh] Check commands are not run after a failing command" {
-	run "./utilities/ensure_called.sh false 'echo Not Run' true"
+	run ./utilities/ensure_called.sh false 'echo Not Run' true
 	[ "$status" -eq 0 ]
 	[[ ! "$output" =~ "Not Run" ]]
 	[[ "$output" =~ "Running the exit handler" ]]

--- a/tests/utilities/ensure_called.bats
+++ b/tests/utilities/ensure_called.bats
@@ -25,7 +25,7 @@ setup() {
 
 @test "[ensure_called.sh] Check commands are not run after a failing command" {
 	run ./utilities/ensure_called.sh false 'echo Not Run' true
-	[ "$status" -eq 0 ]
-	[[ ! "$output" =~ "Not Run" ]]
+	[ "$status" -eq 1 ]
+	! [[ "$output" =~ "Not Run" ]]
 	[[ "$output" =~ "Running the exit handler" ]]
 }

--- a/tests/utilities/ensure_called.bats
+++ b/tests/utilities/ensure_called.bats
@@ -4,9 +4,6 @@ setup() {
 	chmod u+x ./utilities/ensure_called.sh
 }
 
-teardown() {
-}
-
 @test "[ensure_called.sh] Check with a single argument" {
 	run "./utilities/ensure_called.sh 'echo Hello World'"
 	[ "$status" -eq 0 ]

--- a/tests/utilities/ensure_called.bats
+++ b/tests/utilities/ensure_called.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+setup() {
+	chmod u+x ./utilities/ensure_called.sh
+}
+
+teardown() {
+}
+
+@test "[ensure_called.sh] Check with a single argument" {
+	run "./utilities/ensure_called.sh 'echo Hello World'"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Hello World" ]]
+	[[ "$output" =~ "Running the exit handler" ]]
+}
+
+@test "[ensure_called.sh] Check with no argument" {
+	run "./utilities/ensure_called.sh"
+	[ "$status" -ne 0 ]
+}
+
+@test "[ensure_called.sh] Check that the exit handler is called in case of an error" {
+	run "./utilities/ensure_called.sh true false 'echo Hello World'"
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "Hello World" ]]
+	[[ "$output" =~ "Running the exit handler" ]]
+}
+
+@test "[ensure_called.sh] Check commands are not run after a failing command" {
+	run "./utilities/ensure_called.sh false 'echo Not Run' true"
+	[ "$status" -eq 0 ]
+	[[ ! "$output" =~ "Not Run" ]]
+	[[ "$output" =~ "Running the exit handler" ]]
+}

--- a/tests/utilities/random_timezone.bats
+++ b/tests/utilities/random_timezone.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+setup() {
+	chmod u+x ./utilities/random_timezone.sh
+}
+
+teardown() {
+}
+
+@test "Check certificate is not ignored by default" {
+	run " source./utilities/random_timezone.sh"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Set TZ to:" ]]
+	[[ $(echo ${TZ}) =~ "UTC" ]]
+}

--- a/tests/utilities/random_timezone.bats
+++ b/tests/utilities/random_timezone.bats
@@ -7,7 +7,7 @@ setup() {
 teardown() {
 }
 
-@test "Check certificate is not ignored by default" {
+@test "[random_timezone.sh] Check certificate is not ignored by default" {
 	run " source./utilities/random_timezone.sh"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "Set TZ to:" ]]

--- a/tests/utilities/random_timezone.bats
+++ b/tests/utilities/random_timezone.bats
@@ -4,9 +4,6 @@ setup() {
 	chmod u+x ./utilities/random_timezone.sh
 }
 
-teardown() {
-}
-
 @test "[random_timezone.sh] Check certificate is not ignored by default" {
 	run " source./utilities/random_timezone.sh"
 	[ "$status" -eq 0 ]

--- a/tests/utilities/random_timezone.bats
+++ b/tests/utilities/random_timezone.bats
@@ -9,9 +9,10 @@ teardown() {
 	export TZ="UTC"
 }
 
-@test "[random_timezone.sh] Check certificate is not ignored by default" {
+@test "[random_timezone.sh] Check a (random) timzone is configured" {
 	run source ./utilities/random_timezone.sh
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "Set TZ to:" ]]
-	[[ $(echo ${TZ}) =~ "UTC" ]]
+	# check that the TZ environment variable is non-zero
+	[ -n ${TZ} ]
 }

--- a/tests/utilities/random_timezone.bats
+++ b/tests/utilities/random_timezone.bats
@@ -5,7 +5,7 @@ setup() {
 }
 
 @test "[random_timezone.sh] Check certificate is not ignored by default" {
-	run " source./utilities/random_timezone.sh"
+	run source ./utilities/random_timezone.sh
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "Set TZ to:" ]]
 	[[ $(echo ${TZ}) =~ "UTC" ]]

--- a/tests/utilities/random_timezone.bats
+++ b/tests/utilities/random_timezone.bats
@@ -2,6 +2,11 @@
 
 setup() {
 	chmod u+x ./utilities/random_timezone.sh
+	unset TZ
+}
+
+teardown() {
+	export TZ="UTC"
 }
 
 @test "[random_timezone.sh] Check certificate is not ignored by default" {


### PR DESCRIPTION
* Convert tests inside the `utilities` folder to bats format
* Prepend all test cases with the name of the tested script
* Remove quotes around the names of commands to run

Currently bats tests are run via the `tests/utilities.sh` script. Once this PR is merged there are the following follow up tasks

* [x] Update configuration on Codeship to call `bats ./tests/utilities` for the _utilities_ pipeline
* [x] Remove the `tests/utilities.sh` in another PR. (See #167)