### PR TITLE
Fix PYENV_VERSION usage in python.sh

### DIFF
--- a/languages/python.sh
+++ b/languages/python.sh
@@ -24,7 +24,7 @@ if [ ! -d "${PYENV_ROOT}" ]; then
 fi
 
 # Pyenv itself uses PYENV_VERSION to choose the Python version
-PYENV_VERSION=
+unset PYENV_VERSION
 
 eval "$(pyenv init -)"
 pyenv install --skip-existing "${PYTHON_VERSION}"

--- a/languages/python.sh
+++ b/languages/python.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install a custom Python version.
-# based on pyenv, https://github.com/yyuu/pyenv
+# based on pyenv, https://github.com/pyenv/pyenv
 #
 # Add at least the following environment variables to your project configuration
 # (otherwise the defaults below will be used).
@@ -16,12 +16,15 @@ CACHED_DOWNLOAD="${HOME}/cache/pyenv-${PYENV_VERSION}.tar.gz"
 
 if [ ! -d "${PYENV_ROOT}" ]; then
   mkdir -p "${PYENV_ROOT}"
-  wget --continue --output-document "${CACHED_DOWNLOAD}" "https://github.com/yyuu/pyenv/archive/${PYENV_VERSION}.tar.gz"
+  wget --continue --output-document "${CACHED_DOWNLOAD}" "https://github.com/pyenv/pyenv/archive/${PYENV_VERSION}.tar.gz"
   tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${PYENV_ROOT}"
 
   export PYENV_ROOT
   export PATH="${PYENV_ROOT}/bin:${PATH}"
 fi
+
+# Pyenv itself uses PYENV_VERSION to choose the Python version
+PYENV_VERSION=
 
 eval "$(pyenv init -)"
 pyenv install --skip-existing "${PYTHON_VERSION}"


### PR DESCRIPTION
Unfortunately, pyenv uses `PYENV_VERSION` variable to choose the version of Python. In `languages/python.sh` script, `PYENV_VERSION` is used to choose the version of pyenv itself. If this variable is exported (for example, in project settings), pyenv gets confused and fails as it cannot find non-existing versions of Python.

Example. The following variables are exported:

    PYENV_VERSION=v1.0.10
    PYTHON_VERSION=3.6.1

When `python.sh` is executed, `python --version` command (last line) fails:

    pyenv: version `v1.0.10' is not installed (set by PYENV_VERSION environment variable)

The simplest solution (this commit) is to unset the `PYENV_VERSION` variable before actually using pyenv. Alternatively, another variable name could be used to avoid confusion, but other names look awkward (`PYENV_TOOL_VERSION`?).