### PR TITLE
Add a way to install Elasticsearch plugins

### DIFF
--- a/packages/elasticsearch.sh
+++ b/packages/elasticsearch.sh
@@ -13,6 +13,7 @@
 ELASTICSEARCH_VERSION=${ELASTICSEARCH_VERSION:="1.5.2"}
 ELASTICSEARCH_PORT=${ELASTICSEARCH_PORT:="9333"}
 ELASTICSEARCH_DIR=${ELASTICSEARCH_DIR:="$HOME/el"}
+ELASTICSEARCH_PLUGINS=${ELASTICSEARCH_PLUGINS:=""}
 
 # The download location of version 5.x, and 2.x seems to follow a different URL structure to 1.x\
 # Make sure to use Oracle JDK 8 for Elasticsearch 5.x run the following commands in your script.
@@ -22,11 +23,14 @@ ELASTICSEARCH_DIR=${ELASTICSEARCH_DIR:="$HOME/el"}
 if [ ${ELASTICSEARCH_VERSION:0:1} -eq 5 ]
 then
   ELASTICSEARCH_DL_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz"
+  ELASTICSEARCH_PLUGIN_BIN="${ELASTICSEARCH_DIR}/bin/elasticsearch-plugin"
 elif [ ${ELASTICSEARCH_VERSION:0:1} -eq 2 ]
 then
   ELASTICSEARCH_DL_URL="https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ELASTICSEARCH_VERSION}/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz"
+  ELASTICSEARCH_PLUGIN_BIN="${ELASTICSEARCH_DIR}/bin/plugin"
 else
   ELASTICSEARCH_DL_URL="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz"
+  ELASTICSEARCH_PLUGIN_BIN=""
 fi
 set -e
 
@@ -37,6 +41,13 @@ wget --continue --output-document "${CACHED_DOWNLOAD}" "${ELASTICSEARCH_DL_URL}"
 tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${ELASTICSEARCH_DIR}"
 
 echo "http.port: ${ELASTICSEARCH_PORT}" >> ${ELASTICSEARCH_DIR}/config/elasticsearch.yml
+
+if [ "$ELASTICSEARCH_PLUGINS" ]
+then
+  for i in $ELASTICSEARCH_PLUGINS ; do
+    $ELASTICSEARCH_PLUGIN_BIN "install ${i}"
+  done
+fi
 
 # Make sure to use the exact parameters you want for ElasticSearch
 nohup bash -c "${ELASTICSEARCH_DIR}/bin/elasticsearch 2>&1" &

--- a/packages/elasticsearch.sh
+++ b/packages/elasticsearch.sh
@@ -10,6 +10,9 @@
 # * ELASTICSEARCH_VERSION
 # * ELASTICSEARCH_PORT
 #
+# Plugins can be installed by defining the following environment variables:
+# * ELASTICSEARCH_PLUGINS="analysis-icu ingest-attachment"
+#
 ELASTICSEARCH_VERSION=${ELASTICSEARCH_VERSION:="1.5.2"}
 ELASTICSEARCH_PORT=${ELASTICSEARCH_PORT:="9333"}
 ELASTICSEARCH_DIR=${ELASTICSEARCH_DIR:="$HOME/el"}

--- a/packages/elasticsearch.sh
+++ b/packages/elasticsearch.sh
@@ -45,7 +45,7 @@ echo "http.port: ${ELASTICSEARCH_PORT}" >> ${ELASTICSEARCH_DIR}/config/elasticse
 if [ "$ELASTICSEARCH_PLUGINS" ]
 then
   for i in $ELASTICSEARCH_PLUGINS ; do
-    $ELASTICSEARCH_PLUGIN_BIN "install ${i}"
+    eval "${ELASTICSEARCH_PLUGIN_BIN} install ${i}"
   done
 fi
 


### PR DESCRIPTION
Hi !

Some of my project require [analysis-icu](https://www.elastic.co/guide/en/elasticsearch/plugins/2.4/analysis-icu.html) Elasticsearch plugin.

Here is a proposal to easily install those plugin before starting elasticsearch server.
What do you think about it ?

I'm not particularly familiar with Bash, any suggestion or improvement welcome.