### PR TITLE
ShellCheck cache

### DIFF
--- a/tests/cache/bower.bats
+++ b/tests/cache/bower.bats
@@ -1,12 +1,12 @@
 #!/usr/bin/env bats
 
 setup() {
-  rm -rf "${HOME}/cache/*"
+  rm -rf "${HOME}/cache/bower/*"
 	chmod u+x ./cache/bower.sh
 }
 
 teardown() {
-  rm -rf "./node_modules" "${HOME}/cache/*"
+  rm -rf "./node_modules" "${HOME}/cache/bower/*"
 }
 
 @test "[bower.sh] Configure caching bower packages" {

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -19,7 +19,7 @@ fi
 
 # install bats for running tests
 info "Installing Bats"
-bash packages/bats.sh 1>/dev/null
+bash packages/bats.sh >/dev/null 2>&1
 bats --version
 
 # clear the dependency cache
@@ -36,7 +36,7 @@ mkdir -p "${HOME}/cache/"
 # in any of the tests.
 if [ ! -f "${HOME}/bin/shellcheck" ]; then
 	info "Installing ShellCheck"
-	bash packages/shellcheck.sh 1>/dev/null
+	bash packages/shellcheck.sh >/dev/null
 	shellcheck --version
 else
 	cp "${HOME}/bin/shellcheck" "${HOME}/cache/shellcheck"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,21 +1,29 @@
 #!/bin/sh
 
+debug() { echo "\033[0;37m$*\033[0m"; }
+info() { echo "\033[0;36m$*\033[0m"; }
+error() { >&2  echo "\033[0;31m$*\033[0m"; }
+fail() { error ${1}; exit ${2:-1}; }
+
 set -euo pipefail
 
 # save the precompiled ShellCheck binary if it's available
 # as we clear the dependency cache as part of the setup steps we either need to
 # recompile the binary on each run, or move it
 if [ -f "${HOME}/cache/shellcheck" ]; then
+	info "Using cached ShellCheck binary"
 	rm -rf "${HOME}/bin/shellcheck"
 	cp  "${HOME}/cache/shellcheck" "${HOME}/bin/shellcheck"
 fi
 
 # install bats for running tests
+info "Installing Bats"
 bash packages/bats.sh
 
 # clear the dependency cache
 # this code can be deleted once all tests have been converted to bats format
 # and take care of clearing their downloaded artifacts themselves.
+info "Resetting the '${HOME}/cache' folder"
 rm -rf "${HOME}/cache"
 mkdir -p "${HOME}/cache/"
 
@@ -24,5 +32,6 @@ mkdir -p "${HOME}/cache/"
 # won't be cached. we also have to make sure to not clear the complete cache
 # in any of the tests.
 if [ ! -f "${HOME}/bin/shellcheck" ]; then
-	bash packages/shellcheck.sh
+	info "Installing ShellCheck"
+	bash packages/shellcheck.sh 1>/dev/null
 fi

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-debug() { echo "\033[0;37m$*\033[0m"; }
-info() { echo "\033[0;36m$*\033[0m"; }
-error() { >&2  echo "\033[0;31m$*\033[0m"; }
+debug() { echo -e "\033[0;37m$*\033[0m"; }
+info() { echo -e "\033[0;36m$*\033[0m"; }
+error() { >&2  echo -e "\033[0;31m$*\033[0m"; }
 fail() { error ${1}; exit ${2:-1}; }
 
 set -euo pipefail
@@ -14,11 +14,13 @@ if [ -f "${HOME}/cache/shellcheck" ]; then
 	info "Using cached ShellCheck binary"
 	rm -rf "${HOME}/bin/shellcheck"
 	cp  "${HOME}/cache/shellcheck" "${HOME}/bin/shellcheck"
+	shellcheck --version
 fi
 
 # install bats for running tests
 info "Installing Bats"
-bash packages/bats.sh
+bash packages/bats.sh 1>/dev/null
+bats --version
 
 # clear the dependency cache
 # this code can be deleted once all tests have been converted to bats format
@@ -34,4 +36,5 @@ mkdir -p "${HOME}/cache/"
 if [ ! -f "${HOME}/bin/shellcheck" ]; then
 	info "Installing ShellCheck"
 	bash packages/shellcheck.sh 1>/dev/null
+	shellcheck --version
 fi

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -29,7 +29,8 @@ info "Resetting the '${HOME}/cache' folder"
 rm -rf "${HOME}/cache"
 mkdir -p "${HOME}/cache/"
 
-# install ShellCheck if it's not already available.
+# install ShellCheck if it's not already available or copy the binary back to
+# the cache folder.
 # we have to run this after clearing the cache, as otherwise the built binary
 # won't be cached. we also have to make sure to not clear the complete cache
 # in any of the tests.
@@ -37,4 +38,6 @@ if [ ! -f "${HOME}/bin/shellcheck" ]; then
 	info "Installing ShellCheck"
 	bash packages/shellcheck.sh 1>/dev/null
 	shellcheck --version
+else
+	cp "${HOME}/bin/shellcheck" "${HOME}/cache/shellcheck"
 fi

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -14,5 +14,15 @@ fi
 bash packages/bats.sh
 
 # clear the dependency cache
+# this code can be deleted once all tests have been converted to bats format
+# and take care of clearing their downloaded artifacts themselves.
 rm -rf "${HOME}/cache"
 mkdir -p "${HOME}/cache/"
+
+# install ShellCheck if it's not already available.
+# we have to run this after clearing the cache, as otherwise the built binary
+# won't be cached. we also have to make sure to not clear the complete cache
+# in any of the tests.
+if [ ! -f "${HOME}/bin/shellcheck" ]; then
+	bash packages/shellcheck.sh
+fi

--- a/tests/shellcheck.sh
+++ b/tests/shellcheck.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-debug() { echo "\033[0;37m$*\033[0m"; }
-info() { echo "\033[0;36m$*\033[0m"; }
-error() { >&2  echo "\033[0;31m$*\033[0m"; }
+debug() { echo -e "\033[0;37m$*\033[0m"; }
+info() { echo -e "\033[0;36m$*\033[0m"; }
+error() { >&2  echo -e "\033[0;31m$*\033[0m"; }
 fail() { error ${1}; exit ${2:-1}; }
 
 set -euo pipefail

--- a/tests/shellcheck.sh
+++ b/tests/shellcheck.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 
+debug() { echo "\033[0;37m$*\033[0m"; }
+info() { echo "\033[0;36m$*\033[0m"; }
+error() { >&2  echo "\033[0;31m$*\033[0m"; }
+fail() { error ${1}; exit ${2:-1}; }
+
 set -euo pipefail
 
-if [ ! -e "${HOME}/bin/shellcheck" ]; then
-	echo "Installing ShellCheck"
-	bash packages/shellcheck.sh
-fi
-
-echo "Running ShellCheck..."
-echo "...on cache scripts"
+info "Running ShellCheck..."
+info "...on cache scripts"
 shellcheck cache/*
 
-echo "...on deployment scripts (PENDING)"
+info "...on deployment scripts (PENDING)"
 shellcheck deployments/* || true
 
-echo "...on language scripts"
+info "...on language scripts"
 shellcheck languages/*
 
-echo "...on notification scripts (PENDING)"
+info "...on notification scripts (PENDING)"
 shellcheck notifications/* || true
 
-echo "...on package scripts (PENDING)"
+info "...on package scripts (PENDING)"
 shellcheck packages/* || true
 
-echo "...on utility scripts (PENDING)"
+info "...on utility scripts (PENDING)"
 # Ignore SC1071: ShellCheck only supports sh/bash/ksh scripts
 shellcheck -e SC1071 utilities/* || true


### PR DESCRIPTION
I tried to cache the `shellcheck` binary in between builds (as building from source takes quite a bit), but missed that we clear the `$HOME/cache` folder as part of the setup process. (Thus making the cache not work.)

This PR installs ShellCheck as part of the setup process, after the cache folder is cleared, making sure the compiled binary is cached in between builds.