### PR TITLE
Redirect background jobs stdout to /dev/null

### DIFF
--- a/packages/dynamodb.sh
+++ b/packages/dynamodb.sh
@@ -23,6 +23,6 @@ tar -xaf "${CACHED_DOWNLOAD}" --directory "${DYNAMODB_DIR}"
 # Make sure to use the exact parameters you want for DynamoDB and give it enough sleep time to properly start up
 (
   cd ${DYNAMODB_DIR} || exit 1
-  nohup bash -c "java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -sharedDb -inMemory -port ${DYNAMODB_PORT} 2>&1" &
+  bash -c "java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -sharedDb -inMemory -port ${DYNAMODB_PORT} 2>&1 >dev/null" >/dev/null & disown
   sleep "${DYNAMODB_WAIT_TIME}"
 )

--- a/packages/elasticsearch.sh
+++ b/packages/elasticsearch.sh
@@ -39,5 +39,5 @@ tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${ELASTICSEARCH_
 echo "http.port: ${ELASTICSEARCH_PORT}" >> ${ELASTICSEARCH_DIR}/config/elasticsearch.yml
 
 # Make sure to use the exact parameters you want for ElasticSearch
-nohup bash -c "${ELASTICSEARCH_DIR}/bin/elasticsearch 2>&1" &
+bash -c "${ELASTICSEARCH_DIR}/bin/elasticsearch 2>&1 >dev/null" >/dev/null & disown
 wget --retry-connrefused --tries=0 --waitretry=1 -O- -nv http://localhost:${ELASTICSEARCH_PORT}

--- a/packages/influxdb.sh
+++ b/packages/influxdb.sh
@@ -19,7 +19,7 @@ set -e
 wget --continue --output-document "${CACHED_DOWNLOAD}" "${INFLUX_URL}"
 tar -xvf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${INFLUX_DIR}"
 
-nohup bash -c "${INFLUX_DIR}/influxdb-1.2.2-1/usr/bin/influxd 2>&1" &
+bash -c "${INFLUX_DIR}/influxdb-1.2.2-1/usr/bin/influxd 2>&1>/dev/null" >/dev/null & disown
 sleep "${INFLUX_WAIT_TIME}"
 
 if [ "$INFLUX_DB" != "" ]

--- a/packages/mongodb.sh
+++ b/packages/mongodb.sh
@@ -24,7 +24,7 @@ tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${MONGODB_DIR}"
 # Allow users to opt out of starting MongoDB (ie: they just need the tools)
 if [ $MONGODB_START = "Y" ]; then
   # Make sure to use the exact parameters you want for MongoDB and give it enough sleep time to properly start up
-  nohup bash -c "LC_ALL=C ${MONGODB_DIR}/bin/mongod --port ${MONGODB_PORT} --dbpath ${MONGODB_DIR} 2>&1" &
+  bash -c "LC_ALL=C ${MONGODB_DIR}/bin/mongod --port ${MONGODB_PORT} --dbpath ${MONGODB_DIR} 2>&1 >/dev/null" >/dev/null & disown
   sleep "${MONGODB_WAIT_TIME}"
 fi
 


### PR DESCRIPTION
If background processes leak their stdout into other steps our build platform gets a bit unstable and infrequently fails. This should work around background processes generating any output. (yes, even the single line nohup outputs might just be enough)