### PR TITLE
Minor improvements to the test setup

### DIFF
--- a/tests/languages.sh
+++ b/tests/languages.sh
@@ -1,28 +1,45 @@
 #!/bin/bash
 
-set -e
+debug() { echo -e "\033[0;37m$*\033[0m"; }
+info() { echo -e "\033[0;36m$*\033[0m"; }
+error() { >&2  echo -e "\033[0;31m$*\033[0m"; }
+fail() { error ${1}; exit ${2:-1}; }
+
+test_header() {
+  echo -e "\n\n"
+  info '#'
+  info "# ${*}"
+  info '#'
+}
+
+set -euo pipefail
 
 # Dart
+test_header "Dart"
 export DART_VERSION="1.22.1"
 bash languages/dart.sh
 dart --version 2>&1 | grep "${DART_VERSION}"
 
 # Erlang
+test_header "Erlang"
 export ERLANG_VERSION="19.2"
 source languages/erlang.sh
 erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), erlang:display(erlang:binary_to_list(Version)), halt().' -noshell | grep "${ERLANG_VERSION}"
 
 # Elixir, requires the Erlang script above
+test_header "Elixir"
 export ELIXIR_VERSION="1.4.2"
 source languages/elixir.sh
 elixir --version | grep "${ELIXIR_VERSION}"
 
 # Go
+test_header "Go"
 export GO_VERSION="1.8"
 source languages/go.sh
 go version | grep "${GO_VERSION}"
 
 # Python 2.*
+test_header "Python"
 export PYTHON_VERSION="2.7.13"
 source languages/python.sh
 python --version 2>&1 | grep "${PYTHON_VERSION}"
@@ -33,10 +50,12 @@ source languages/python.sh
 python --version 2>&1 | grep "${PYTHON_VERSION}"
 
 # R
+test_header "R"
 export R_VERSION="3.3.2"
 source languages/r.sh
 R --version | grep "${R_VERSION}"
 
 # Rust
+test_header "Rust"
 source languages/rust.sh
 rustc --version

--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -97,7 +97,7 @@ if [ ${PIPELINE_ID} -eq "1" ]; then
 fi
 
 # MySQL 5.7
-if [ ${PIPELINE_ID} -eq "2" ]; then
+if [ ${PIPELINE_ID} -eq "1" ]; then
 	test_header "MySQL"
 	export MYSQL_VERSION="5.7.17"
 	bash packages/mysql-5.7.sh
@@ -124,7 +124,7 @@ if [ ${PIPELINE_ID} -eq "1" ]; then
 fi
 
 # Poppler
-if [ ${PIPELINE_ID} -eq "2" ]; then
+if [ ${PIPELINE_ID} -eq "1" ]; then
 	test_header "Poppler"
 	export POPPLER_VERSION="0.52.0"
 	bash packages/poppler.sh
@@ -132,7 +132,7 @@ if [ ${PIPELINE_ID} -eq "2" ]; then
 fi
 
 # QPDF
-if [ ${PIPELINE_ID} -eq "2" ]; then
+if [ ${PIPELINE_ID} -eq "1" ]; then
 	test_header "QPDF"
 	export QPDF_VERSION="6.0.0"
 	bash packages/qpdf.sh
@@ -157,7 +157,7 @@ if [ ${PIPELINE_ID} -eq "1" ]; then
 fi
 
 # Haskell Stack
-if [ ${PIPELINE_ID} -eq "2" ]; then
+if [ ${PIPELINE_ID} -eq "1" ]; then
 	test_header "Haskell Stack"
 	export HASKELL_STACK_VERSION="1.3.2"
 	bash packages/stack.sh

--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -13,7 +13,7 @@ test_header() {
 }
 
 #set -euo pipefail
-set -eo pipefail
+set -e
 
 PIPELINE_ID="${1}"
 

--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -12,125 +12,162 @@ test_header() {
   info '#'
 }
 
-set -euo pipefail
+#set -euo pipefail
+set -eo pipefail
+
+PIPELINE_ID="${1}"
 
 # ChromeDriver
-test_header "ChromeDriver"
-export CHROMEDRIVER_VERSION="2.27"
-bash packages/chromedriver.sh
-chromedriver --version | grep "${CHROMEDRIVER_VERSION}"
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "ChromeDriver"
+	export CHROMEDRIVER_VERSION="2.27"
+	bash packages/chromedriver.sh
+	chromedriver --version | grep "${CHROMEDRIVER_VERSION}"
+fi
 
 # Firefox
-test_header "Firefox"
-export FIREFOX_VERSION="51.0.1"
-bash packages/firefox.sh
-firefox --version | grep "${FIREFOX_VERSION}"
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "Firefox"
+	export FIREFOX_VERSION="51.0.1"
+	bash packages/firefox.sh
+	firefox --version | grep "${FIREFOX_VERSION}"
+fi
 
 # Ghostscript
-test_header "Ghostscript"
-export GHOSTSCRIPT_VERSION="9.20"
-bash packages/ghostscript.sh
-ghostscript -version | grep "${GHOSTSCRIPT_VERSION}"
+if [ ${PIPELINE_ID} -eq "2" ]; then
+	test_header "Ghostscript"
+	export GHOSTSCRIPT_VERSION="9.20"
+	bash packages/ghostscript.sh
+	ghostscript -version | grep "${GHOSTSCRIPT_VERSION}"
+fi
 
 # Git
-test_header "Git"
-export GIT_VERSION="2.12.0"
-bash packages/git.sh
-git --version | grep "${GIT_VERSION}"
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "Git"
+	export GIT_VERSION="2.12.0"
+	bash packages/git.sh
+	git --version | grep "${GIT_VERSION}"
+fi
 
 # Git LFS
-test_header "Git LFS"
-export GIT_LFS_VERSION="2.0.0"
-bash packages/git-lfs.sh
-git lfs version | grep "git-lfs/${GIT_LFS_VERSION}"
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "Git LFS"
+	export GIT_LFS_VERSION="2.0.0"
+	bash packages/git-lfs.sh
+	git lfs version | grep "git-lfs/${GIT_LFS_VERSION}"
 
-# test warning message
-unset GIT_LFS_VERSION
-bash packages/git-lfs.sh | grep "Warning"
-git lfs version | grep "git-lfs/1.5.6"
+	# test warning message
+	unset GIT_LFS_VERSION
+	bash packages/git-lfs.sh | grep "Warning"
+	git lfs version | grep "git-lfs/1.5.6"
+fi
 
 # Google Cloud SDK
-test_header "Google Cloud SDK"
-source packages/google-cloud-sdk.sh
-gcloud --version
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "Google Cloud SDK"
+	source packages/google-cloud-sdk.sh
+	gcloud --version
+fi
 
 # ImageMagick
-test_header "ImageMagick"
-export IMAGEMAGICK_VERSION="7.0.5-0"
-bash packages/imagemagick.sh
-identify -version | grep "${IMAGEMAGICK_VERSION}"
+if [ ${PIPELINE_ID} -eq "2" ]; then
+	test_header "ImageMagick"
+	export IMAGEMAGICK_VERSION="7.0.5-0"
+	bash packages/imagemagick.sh
+	identify -version | grep "${IMAGEMAGICK_VERSION}"
+fi
 
 # MongoDB
-test_header "MongoDB"
-export MONGODB_PORT="27018"
-export MONGODB_VERSION="3.4.0"
-bash packages/mongodb.sh
-netstat -lnp | grep "${MONGODB_PORT}.*mongod"
-kill "$(cat ${HOME}/mongodb/mongod.lock)"
-rm -rf "${HOME}/mongodb/"
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "MongoDB"
+	export MONGODB_PORT="27018"
+	export MONGODB_VERSION="3.4.0"
+	bash packages/mongodb.sh
+	netstat -lnp | grep "${MONGODB_PORT}.*mongod"
+	kill "$(cat ${HOME}/mongodb/mongod.lock)"
+	rm -rf "${HOME}/mongodb/"
 
-export MONGODB_PORT="27019"
-export MONGODB_VERSION="3.4.4"
-export MONGODB_STORAGE_ENGINE="mmapv1"
-bash packages/mongodb.sh
-netstat -lnp | grep "${MONGODB_PORT}.*mongod"
-kill "$(cat ${HOME}/mongodb/mongod.lock)"
-rm -rf "${HOME}/mongodb/"
+	export MONGODB_PORT="27019"
+	export MONGODB_VERSION="3.4.4"
+	export MONGODB_STORAGE_ENGINE="mmapv1"
+	bash packages/mongodb.sh
+	netstat -lnp | grep "${MONGODB_PORT}.*mongod"
+	kill "$(cat ${HOME}/mongodb/mongod.lock)"
+	rm -rf "${HOME}/mongodb/"
+fi
 
 # MySQL 5.7
-test_header "MySQL"
-export MYSQL_VERSION="5.7.17"
-bash packages/mysql-5.7.sh
-"$HOME/mysql-$MYSQL_VERSION/bin/mysql" --defaults-file="$HOME/mysql-$MYSQL_VERSION/my.cnf" --version | grep "${MYSQL_VERSION}"
-netstat -lnp | grep "3307"
+if [ ${PIPELINE_ID} -eq "2" ]; then
+	test_header "MySQL"
+	export MYSQL_VERSION="5.7.17"
+	bash packages/mysql-5.7.sh
+	"$HOME/mysql-$MYSQL_VERSION/bin/mysql" --defaults-file="$HOME/mysql-$MYSQL_VERSION/my.cnf" --version | grep "${MYSQL_VERSION}"
+	netstat -lnp | grep "3307"
+fi
 
 # Neo4j
-test_header "Neo4j"
-export NEO4J_VERSION="2.2.2"
-bash packages/neo4j.sh
-netstat -lnp | grep "7473.*java"
-netstat -lnp | grep "7474.*java"
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "Neo4j"
+	export NEO4J_VERSION="2.2.2"
+	bash packages/neo4j.sh
+	netstat -lnp | grep "7473.*java"
+	netstat -lnp | grep "7474.*java"
+fi
 
 # Phalcon PHP framework
-test_header "Phalcon"
-export PHALCON_VERSION="3.0.3"
-phpenv local 5.6
-bash packages/phalcon.sh
-php -m | grep phalcon
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "Phalcon"
+	export PHALCON_VERSION="3.0.3"
+	phpenv local 5.6
+	bash packages/phalcon.sh
+	php -m | grep phalcon
+fi
 
 # Poppler
-test_header "Poppler"
-export POPPLER_VERSION="0.52.0"
-bash packages/poppler.sh
-pdftotext -v 2>&1 | grep "${POPPLER_VERSION}"
+if [ ${PIPELINE_ID} -eq "2" ]; then
+	test_header "Poppler"
+	export POPPLER_VERSION="0.52.0"
+	bash packages/poppler.sh
+	pdftotext -v 2>&1 | grep "${POPPLER_VERSION}"
+fi
 
 # QPDF
-test_header "QPDF"
-export QPDF_VERSION="6.0.0"
-bash packages/qpdf.sh
-qpdf --version | grep "${QPDF_VERSION}"
+if [ ${PIPELINE_ID} -eq "2" ]; then
+	test_header "QPDF"
+	export QPDF_VERSION="6.0.0"
+	bash packages/qpdf.sh
+	qpdf --version | grep "${QPDF_VERSION}"
+fi
 
 # sbt
-test_header "SBT"
-export SBT_VERSION="0.13.8"
-bash packages/sbt.sh
-sbt --version | grep "${SBT_VERSION}"
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "SBT"
+	export SBT_VERSION="0.13.8"
+	bash packages/sbt.sh
+	sbt --version | grep "${SBT_VERSION}"
+fi
 
 # Selenium Server
-test_header "Selenium"
-export SELENIUM_VERSION="2.46.0"
-export SELENIUM_PORT="4444"
-bash packages/selenium_server.sh
-netstat -lnp | grep "${SELENIUM_PORT}.*java"
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "Selenium"
+	export SELENIUM_VERSION="2.46.0"
+	export SELENIUM_PORT="4444"
+	bash packages/selenium_server.sh
+	netstat -lnp | grep "${SELENIUM_PORT}.*java"
+fi
 
 # Haskell Stack
-test_header "Haskell Stack"
-export HASKELL_STACK_VERSION="1.3.2"
-bash packages/stack.sh
-stack --version | grep "${HASKELL_STACK_VERSION}"
+if [ ${PIPELINE_ID} -eq "2" ]; then
+	test_header "Haskell Stack"
+	export HASKELL_STACK_VERSION="1.3.2"
+	bash packages/stack.sh
+	stack --version | grep "${HASKELL_STACK_VERSION}"
+fi
 
 # Tomcat
-test_header "Tomcat"
-export TOMCAT_VERSION="8.5.12"
-bash packages/tomcat.sh
-bash ${HOME}/tomcat/bin/version.sh | grep "Apache Tomcat/${TOMCAT_VERSION}"
+if [ ${PIPELINE_ID} -eq "1" ]; then
+	test_header "Tomcat"
+	export TOMCAT_VERSION="8.5.12"
+	bash packages/tomcat.sh
+	bash ${HOME}/tomcat/bin/version.sh | grep "Apache Tomcat/${TOMCAT_VERSION}"
+fi

--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -1,28 +1,45 @@
 #!/bin/bash
 
-set -e
+debug() { echo -e "\033[0;37m$*\033[0m"; }
+info() { echo -e "\033[0;36m$*\033[0m"; }
+error() { >&2  echo -e "\033[0;31m$*\033[0m"; }
+fail() { error ${1}; exit ${2:-1}; }
+
+test_header() {
+  echo -e "\n\n"
+  info '#'
+  info "# ${*}"
+  info '#'
+}
+
+set -euo pipefail
 
 # ChromeDriver
+test_header "ChromeDriver"
 export CHROMEDRIVER_VERSION="2.27"
 bash packages/chromedriver.sh
 chromedriver --version | grep "${CHROMEDRIVER_VERSION}"
 
 # Firefox
+test_header "Firefox"
 export FIREFOX_VERSION="51.0.1"
 bash packages/firefox.sh
 firefox --version | grep "${FIREFOX_VERSION}"
 
 # Ghostscript
+test_header "Ghostscript"
 export GHOSTSCRIPT_VERSION="9.20"
 bash packages/ghostscript.sh
 ghostscript -version | grep "${GHOSTSCRIPT_VERSION}"
 
 # Git
+test_header "Git"
 export GIT_VERSION="2.12.0"
 bash packages/git.sh
 git --version | grep "${GIT_VERSION}"
 
 # Git LFS
+test_header "Git LFS"
 export GIT_LFS_VERSION="2.0.0"
 bash packages/git-lfs.sh
 git lfs version | grep "git-lfs/${GIT_LFS_VERSION}"
@@ -33,15 +50,18 @@ bash packages/git-lfs.sh | grep "Warning"
 git lfs version | grep "git-lfs/1.5.6"
 
 # Google Cloud SDK
+test_header "Google Cloud SDK"
 source packages/google-cloud-sdk.sh
 gcloud --version
 
 # ImageMagick
+test_header "ImageMagick"
 export IMAGEMAGICK_VERSION="7.0.5-0"
 bash packages/imagemagick.sh
 identify -version | grep "${IMAGEMAGICK_VERSION}"
 
 # MongoDB
+test_header "MongoDB"
 export MONGODB_PORT="27018"
 export MONGODB_VERSION="3.4.0"
 bash packages/mongodb.sh
@@ -58,50 +78,59 @@ kill "$(cat ${HOME}/mongodb/mongod.lock)"
 rm -rf "${HOME}/mongodb/"
 
 # MySQL 5.7
+test_header "MySQL"
 export MYSQL_VERSION="5.7.17"
 bash packages/mysql-5.7.sh
 "$HOME/mysql-$MYSQL_VERSION/bin/mysql" --defaults-file="$HOME/mysql-$MYSQL_VERSION/my.cnf" --version | grep "${MYSQL_VERSION}"
 netstat -lnp | grep "3307"
 
 # Neo4j
+test_header "Neo4j"
 export NEO4J_VERSION="2.2.2"
 bash packages/neo4j.sh
 netstat -lnp | grep "7473.*java"
 netstat -lnp | grep "7474.*java"
 
 # Phalcon PHP framework
+test_header "Phalcon"
 export PHALCON_VERSION="3.0.3"
 phpenv local 5.6
 bash packages/phalcon.sh
 php -m | grep phalcon
 
 # Poppler
+test_header "Poppler"
 export POPPLER_VERSION="0.52.0"
 bash packages/poppler.sh
 pdftotext -v 2>&1 | grep "${POPPLER_VERSION}"
 
 # QPDF
+test_header "QPDF"
 export QPDF_VERSION="6.0.0"
 bash packages/qpdf.sh
 qpdf --version | grep "${QPDF_VERSION}"
 
 # sbt
+test_header "SBT"
 export SBT_VERSION="0.13.8"
 bash packages/sbt.sh
 sbt --version | grep "${SBT_VERSION}"
 
 # Selenium Server
+test_header "Selenium"
 export SELENIUM_VERSION="2.46.0"
 export SELENIUM_PORT="4444"
 bash packages/selenium_server.sh
 netstat -lnp | grep "${SELENIUM_PORT}.*java"
 
 # Haskell Stack
+test_header "Haskell Stack"
 export HASKELL_STACK_VERSION="1.3.2"
 bash packages/stack.sh
 stack --version | grep "${HASKELL_STACK_VERSION}"
 
 # Tomcat
+test_header "Tomcat"
 export TOMCAT_VERSION="8.5.12"
 bash packages/tomcat.sh
 bash ${HOME}/tomcat/bin/version.sh | grep "Apache Tomcat/${TOMCAT_VERSION}"


### PR DESCRIPTION
* Split the packages pipeline in two. See https://app.codeship.com/projects/74080/builds/25775488 for a sample build. 

    They are not perfectly balanced right now, but the three longest running pipelines right now are the following and this still cuts down on build time by quite a bit.

  * `languages.sh` with 14:02 min
  * `packages.sh 1` with 17:02 min
  * `packages.sh 2` with 12:44 min

* Add headers to each group of tests to make the logs a bit more readable.
* Those builds also didn't run into the issue `master` is currently running in and I wasn't able to reproduce the failing command on a debug build (on the `master` branch) either.

   I'd like to merge this and see if `master` is green and if not investigate further.