### PR TITLE
Google Cloud SDK package script documentation update

### DIFF
--- a/packages/google-cloud-sdk.sh
+++ b/packages/google-cloud-sdk.sh
@@ -5,9 +5,14 @@
 # command to your project's setup commands:
 # source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/google-cloud-sdk.sh)"
 #
-# Add the following environment variables to your project configuration
+# Add the following environment variables to your project configuration:
 # * GOOGLE_CLOUD_KEY
+#   * Set this variable to the contents of the "Service account key" JSON credentials file
+#     downloaded from "APIs & Services > Credentials" in the Google Cloud Platform console.
+#     You can safely copy-paste the entire contents of the file directly into the VALUE
+#     field when configuring this environment variable.
 # * GOOGLE_CLOUD_PROJECT_ID
+#   * Set this variable to the value of the `project_id` property found in the above JSON file.
 
 GOOGLE_CLOUD_DIR=${GOOGLE_CLOUD_DIR:=$HOME/google-cloud-sdk}
 CACHED_DOWNLOAD="${HOME}/cache/google-cloud-sdk.tar.gz"


### PR DESCRIPTION
I was directed to this repository when I asked about using an updated version of the Google App Engine SDK to deploy our app. Adding the appropriate one-liner to our Deploy configuration was trivial, but the contents of the environment variables were very ambiguous.

After some experimentation, I confirmed the expected values of `GOOGLE_CLOUD_KEY` and `GOOGLE_CLOUD_PROJECT_ID`, so I decided to add some additional comments to the script to make it more explicit what values should be set for these environment variables.

After configuring the environment variables as per the updated documentation in this PR, I was able to successfully deploy a Django 1.11 app to Google App Engine using the latest version of the SDK (v168.0.0 as of this PR) as installed by this script.