### PR TITLE
Update geckodriver script

### DIFF
--- a/packages/geckodriver.sh
+++ b/packages/geckodriver.sh
@@ -13,9 +13,9 @@ GECKODRIVER_VERSION=${GECKODRIVER_VERSION:="0.19.1"}
 
 set -e
 
-CACHED_DOWNLOAD="${HOME}/cache/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz"
+CACHED_DOWNLOAD="${HOME}/cache/geckodriver-v${GECKODRIVER_VERSION}-linux64-precompiled.tar.gz"
 
-rm "${HOME}/bin/geckodriver"
+rm -rf "${HOME}/bin/geckodriver"
 wget --continue --output-document "${CACHED_DOWNLOAD}" "https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz"
 tar -xaf "${CACHED_DOWNLOAD}" --directory "${HOME}/bin"
 

--- a/tests/packages/geckodriver.bats
+++ b/tests/packages/geckodriver.bats
@@ -5,7 +5,7 @@ setup() {
 }
 
 @test "[geckodriver.sh] Installs successfully" {
-  rm -f "${HOME}/cache/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz"
+  rm -f "${HOME}/cache/geckodriver-v${GECKODRIVER_VERSION}-linux64-precompiled.tar.gz"
   run ./packages/geckodriver.sh
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Use a different file for the precompiled package cache, since this script fails if the src package is cached instead.
Also force removal of `${HOME}/bin/geckodriver`, since that command will fail if the file does not exist (and thus break the script)