### PR TITLE
Replace wget for poppler tar.

### DIFF
--- a/packages/poppler.sh
+++ b/packages/poppler.sh
@@ -18,7 +18,7 @@ if [ ! -d "${POPPLER_DIR}" ]; then
   CACHED_DOWNLOAD="${HOME}/cache/poppler-${POPPLER_VERSION}.tar.xz"
 
   mkdir -p "${HOME}/poppler"
-  wget --continue --output-document "${CACHED_DOWNLOAD}" "https://poppler.freedesktop.org/poppler-${POPPLER_VERSION}.tar.xz"
+  curl "https://poppler.freedesktop.org/poppler-${POPPLER_VERSION}.tar.xz" --create-dirs -o "${CACHED_DOWNLOAD}"
   tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${HOME}/poppler"
 
   (


### PR DESCRIPTION
I receive "No such file or directory" message using wget.
Switching to curl resolve this issue.