### PR TITLE
Sleep to allow the output stream to become available

### DIFF
--- a/deployments/heroku.sh
+++ b/deployments/heroku.sh
@@ -63,6 +63,9 @@ echo "DEPLOYMENT: $deployment_id"
 
 output_stream_url=`echo "$deployment" | jq -r .output_stream_url`
 
+# Sleep to allow the output stream to become available
+sleep $AFTER_DEPLOYMENT_WAIT_TIME
+
 curl -sS "$output_stream_url"
 
 # Sleep to allow Heroku to store the result of the deployment


### PR DESCRIPTION
Seems it now takes a moment for the output stream to become available. Adding a little sleep time before the script attempts to curl the build stream.