### PR TITLE
Append heroku application name in packaging

### DIFF
--- a/deployments/heroku.sh
+++ b/deployments/heroku.sh
@@ -40,7 +40,7 @@ cd $HEROKU_APP_FOLDER
 #echo "CHECKING Access to Heroku application $HEROKU_APP_NAME"
 #codeship_heroku check_access $HEROKU_APP_NAME
 
-ARTIFACT_PATH=/tmp/deployable_artifact.tar.gz
+ARTIFACT_PATH=/tmp/deployable_artifact_$HEROKU_APP_NAME.tar.gz
 
 echo "PACKAGING tar.gz for deployment"
 tar -pczf $ARTIFACT_PATH ./


### PR DESCRIPTION
Issue: running the scripts in parallel for different apps make deployment to heroku fail. Problem occurs because of race condition I assume.
Solution: append heroku app name to artifact path so each app deployment has different package that doesn't interfere with each other