### PR TITLE
change the download link

### DIFF
--- a/packages/freetds.sh
+++ b/packages/freetds.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 # Install a custom FreeTDS version - http://www.freetds.org
 #
+# Add the following environment variables to your project configuration
+# (otherwise the default below will be used).
+# * FREETDS_VERSION
+#
 # To run this script on Codeship, add the following
 # command to your project's setup commands:
 # \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/freetds.sh | bash -s
 #
+FREETDS_VERSION=${FREETDS_VERSION:="1.1.17"}
 TDS_DIR=${TDS_DIR:=$HOME/cache/freetds}
 
 set -e
@@ -13,7 +18,7 @@ if [ ! -d "${TDS_DIR}" ]; then
   CACHED_DOWNLOAD="${HOME}/cache/freetds.tar.gz"
 
   mkdir -p "${HOME}/freetds"
-  wget --continue --output-document "${CACHED_DOWNLOAD}" "ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.1.17.tar.gz"
+  wget --continue --output-document "${CACHED_DOWNLOAD}" "ftp://ftp.freetds.org/pub/freetds/stable/freetds-${FREETDS_VERSION}.tar.gz"
   tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${HOME}/freetds"
 
   (

--- a/packages/freetds.sh
+++ b/packages/freetds.sh
@@ -13,7 +13,7 @@ if [ ! -d "${TDS_DIR}" ]; then
   CACHED_DOWNLOAD="${HOME}/cache/freetds.tar.gz"
 
   mkdir -p "${HOME}/freetds"
-  wget --continue --output-document "${CACHED_DOWNLOAD}" "ftp://ftp.freetds.org/pub/freetds/stable/freetds-patched.tar.gz"
+  wget --continue --output-document "${CACHED_DOWNLOAD}" "ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.1.17.tar.gz"
   tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${HOME}/freetds"
 
   (


### PR DESCRIPTION
freetds-patched.tar.gz is empty now: ftp://ftp.freetds.org/pub/freetds/stable/ so making changes to allow this script to work without calling the `patched` version.