### PR TITLE
When installing Elasticsearch plugins use batch flag to skip prompts

### DIFF
--- a/packages/elasticsearch.sh
+++ b/packages/elasticsearch.sh
@@ -52,7 +52,7 @@ echo "http.port: ${ELASTICSEARCH_PORT}" >> ${ELASTICSEARCH_DIR}/config/elasticse
 if [ "$ELASTICSEARCH_PLUGINS" ]
 then
   for i in $ELASTICSEARCH_PLUGINS ; do
-    eval "${ELASTICSEARCH_PLUGIN_BIN} install ${i}"
+    eval "${ELASTICSEARCH_PLUGIN_BIN} install -b ${i}"
   done
 fi
 


### PR DESCRIPTION
Some Elasticsearch plugins may include an interactive prompt:

```
-> Downloading ingest-attachment from elastic
[=================================================] 100%   
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@     WARNING: plugin requires additional permissions     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
* java.lang.RuntimePermission accessClassInPackage.sun.java2d.cmm.kcms
* java.lang.RuntimePermission accessDeclaredMembers
* java.lang.RuntimePermission getClassLoader
* java.lang.reflect.ReflectPermission suppressAccessChecks
* java.security.SecurityPermission createAccessControlContext
* java.security.SecurityPermission insertProvider
* java.security.SecurityPermission putProviderProperty.BC
See http://docs.oracle.com/javase/8/docs/technotes/guides/security/permissions.html
for descriptions of what these permissions allow and the associated risks.

Continue with installation? [y/N]ERROR: installation aborted by user
```

To workaround this, make use of the batch flag to automatically accept the prompt:

```
-b, --batch    Enable batch mode explicitly, automatic confirmation of security permission
```