### PR TITLE
Use -nc to check cache before downloading elasticsearch

### DIFF
--- a/packages/elasticsearch.sh
+++ b/packages/elasticsearch.sh
@@ -44,7 +44,7 @@ set -e
 CACHED_DOWNLOAD="${HOME}/cache/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz"
 
 mkdir -p "${ELASTICSEARCH_DIR}"
-wget --continue --output-document "${CACHED_DOWNLOAD}" "${ELASTICSEARCH_DL_URL}"
+wget -nc --continue --output-document "${CACHED_DOWNLOAD}" "${ELASTICSEARCH_DL_URL}"
 tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${ELASTICSEARCH_DIR}"
 
 echo "http.port: ${ELASTICSEARCH_PORT}" >> ${ELASTICSEARCH_DIR}/config/elasticsearch.yml

--- a/packages/elasticsearch.sh
+++ b/packages/elasticsearch.sh
@@ -44,7 +44,9 @@ set -e
 CACHED_DOWNLOAD="${HOME}/cache/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz"
 
 mkdir -p "${ELASTICSEARCH_DIR}"
-wget -nc --continue --output-document "${CACHED_DOWNLOAD}" "${ELASTICSEARCH_DL_URL}"
+if ! [ -f "$CACHED_DOWNLOAD" ]; then
+  wget --continue --output-document "${CACHED_DOWNLOAD}" "${ELASTICSEARCH_DL_URL}"
+fi
 tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${ELASTICSEARCH_DIR}"
 
 echo "http.port: ${ELASTICSEARCH_PORT}" >> ${ELASTICSEARCH_DIR}/config/elasticsearch.yml


### PR DESCRIPTION
Fix tested.
> rof@bionic_daafeb4e-dec9-40a4-b32f-1de67b76fed5_c9fd48beedd3:~$ wget -nc --output-document "${CACHED_DOWNLOAD}" https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
File ‘/home/rof/cache/elasticsearch-2.4.6.tar.gz’ already there; not retrieving.

> rof@bionic_daafeb4e-dec9-40a4-b32f-1de67b76fed5_c9fd48beedd3:~$ wget -nc --continue --output-document "${CACHED_DOWNLOAD}" https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
File ‘/home/rof/cache/elasticsearch-2.4.6.tar.gz’ already there; not retrieving.

> rof@bionic_daafeb4e-dec9-40a4-b32f-1de67b76fed5_c9fd48beedd3:~$ wget -nc --continue --output-document "${CACHED_DOWNLOAD}" https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
File ‘/home/rof/cache/elasticsearch-2.4.6.tar.gz’ already there; not retrieving.
