### PR TITLE
Update to work with latest Hugo version

### DIFF
--- a/packages/hugo.sh
+++ b/packages/hugo.sh
@@ -1,18 +1,15 @@
 #!/bin/sh
-# Install a Hugo, https://gohugo.io/
+# Install Hugo, https://gohugo.io/getting-started/installing/
 #
 # You can either add this here, or configure them on the environment tab of your
 # project settings.
-HUGO_VERSION="0.20"
+HUGO_VERSION="0.81.0"
 HUGO_DIR=${HUGO_DIR:="$HOME/hugo"}
-
 set -e
-CACHED_DOWNLOAD="${HOME}/cache/hugo_${HUGO_VERSION}_linux_amd64.tar.gz"
-
+CACHED_DOWNLOAD="${HOME}/cache/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz"
 mkdir -p "${HUGO_DIR}"
-wget --continue --output-document "${CACHED_DOWNLOAD}" "https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz"
-tar -xaf "${CACHED_DOWNLOAD}" --strip-components=1 --directory "${HUGO_DIR}"
-ln -s "${HUGO_DIR}/hugo_${HUGO_VERSION}_linux_amd64" "${HOME}/bin/hugo"
-
+wget --continue --output-document "${CACHED_DOWNLOAD}" "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz"
+tar -xvf "${CACHED_DOWNLOAD}" --directory "${HUGO_DIR}"
+ln -s "${HUGO_DIR}/hugo" "${HOME}/bin/hugo"
 # check that everything worked
 hugo version


### PR DESCRIPTION
Hugo have changed where to get the binaries from, and the directory structure of the gz package. These updates are to reflect those changes.

- Updated the Hugo version number.
- Modified the wget command to point the new file name to get the binary.
- Modified the `tar` and `ln` commands to match the new file structure.