### PR TITLE
Make mongodb installer script work with mongo 5

### DIFF
--- a/packages/mongodb.sh
+++ b/packages/mongodb.sh
@@ -21,7 +21,7 @@ CACHED_DOWNLOAD="${HOME}/cache/mongodb-linux-x86_64-${MONGODB_VERSION}.tgz"
 
 mkdir -p "${MONGODB_DIR}"
 
-if [ ${UBUNTU_VERSION:0:2} -eq 18 ] && [ ${MONGODB_VERSION:0:1} -eq 4 ]
+if [ ${UBUNTU_VERSION:0:2} -eq 18 ] && [ ${MONGODB_VERSION:0:1} -ge 4 ]
 then
 wget --continue --output-document "${CACHED_DOWNLOAD}" "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-${MONGODB_VERSION}.tgz"
 else


### PR DESCRIPTION
The current script fails for MongoDB 5, because it tries to download the MongoDB installer for Ubuntu 14, which does not exist.