### PR TITLE
Add script for installing custom chrome version

### DIFF
--- a/packages/chrome.sh
+++ b/packages/chrome.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Install a custom Chrome version, https://www.google.com/chrome
+# https://googlechromelabs.github.io/chrome-for-testing/
+# Removes the pre-installed stable version of Chrome and replaces it with the specified version
+# 
+# Add at least the following environment variables to your project configuration
+# (otherwise the defaults below will be used).
+# * CHROME_VERSION
+# 
+# Include in your builds via
+# \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/chrome.sh | bash -s
+
+CHROME_VERSION=${CHROME_VERSION:="122.0.6261.39"}
+CACHED_DOWNLOAD="${HOME}/cache/chrome-linux64-${CHROME_VERSION}.zip"
+
+set -e
+
+sudo dpkg -r google-chrome-stable
+rm "${HOME}/bin/Chrome"
+rm "${HOME}/bin/chrome"
+
+wget --continue --output-document "${CACHED_DOWNLOAD}" "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chrome-linux64.zip"
+unzip -o "${CACHED_DOWNLOAD}" -d "${HOME}/bin"
+
+ln -s "${HOME}/bin/chrome-linux64/chrome" "${HOME}/bin/Chrome"
+ln -s "${HOME}/bin/chrome-linux64/chrome" "${HOME}/bin/chrome"
+
+chrome --version


### PR DESCRIPTION
### Purpose
Adds a script for installing a custom chrome version.

Previously, the browser testing docs (https://docs.cloudbees.com/docs/cloudbees-codeship/latest/basic-continuous-integration/browser-testing) only had steps for using a specific **_ChromeDriver_** version, or the latest **Chrome Beta browser** version.

### Example
Once this gets merged to master:
```
export CHROME_VERSION=136.0.7103.113
\curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/chrome.sh | bash -s
```

### Other notes
This PR took inspiration from the existing chromedriver.sh and chrome-beta scripts, thanks!

Download locations for chrome and chromedriver versions are noted in this json file hosted by Google: https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json

Documentation:
- https://googlechromelabs.github.io/chrome-for-testing/
- https://github.com/GoogleChromeLabs/chrome-for-testing?tab=readme-ov-file#json-api-endpoints

### Testing
This configuration pointing at the script on my fork successfully used the target Chrome version:
```
export CHROME_VERSION=136.0.7103.113
\curl -sSL https://raw.githubusercontent.com/trainer-rx/codeship-scripts/script-for-custom-chrome-version/packages/chrome.sh | bash -s
```